### PR TITLE
Fix: Resuelve error 'MySQL server has gone away' en sub proyectos

### DIFF
--- a/src/pages/sub_proyectos.php
+++ b/src/pages/sub_proyectos.php
@@ -20,6 +20,10 @@ try {
     $proyectos = $stmt_proyectos->fetchAll();
     $stmt_proyectos->closeCursor();
 
+    // Forzar la reconexión para evitar el error "MySQL server has gone away"
+    $pdo = null;
+    $pdo = getDbConnection();
+
     // Obtener sub proyectos filtrados
     $stmt_items = $pdo->prepare("CALL sp_read_all_sub_proyectos(?, ?, ?)");
     $stmt_items->execute([$filter_codigo, $filter_nombre, $filter_proyecto]);


### PR DESCRIPTION
Se presentaba un error "MySQL server has gone away" y un warning "Packets out of order" en la página de sub proyectos.

La causa probable era que la primera consulta a la base de datos, que obtiene la lista de todos los proyectos, devolvía un conjunto de resultados grande que corrompía o cerraba la conexión. La segunda consulta fallaba al intentar usar esta conexión rota.

Esta solución pragmática consiste en forzar una reconexión a la base de datos justo antes de la segunda consulta. Esto asegura que se utilice una conexión nueva y válida, evitando el error.

A futuro, se podría considerar una estrategia de gestión de conexiones más robusta para abordar la causa raíz, como aumentar el `wait_timeout` del servidor MySQL o implementar reintentos de conexión a nivel de la función de base de datos.