### PR TITLE
Fix: Aplica solución pragmática para resolver error persistente de co…

### DIFF
--- a/src/pages/auxiliares.php
+++ b/src/pages/auxiliares.php
@@ -20,6 +20,11 @@ try {
     $tipos_auxiliar = $stmt_tipos->fetchAll();
     $stmt_tipos->closeCursor();
 
+    // Forzar la reconexión. A pesar de las optimizaciones, la conexión sigue fallando
+    // en este punto específico. Esta es la solución más directa para asegurar una conexión viva.
+    $pdo = null;
+    $pdo = getDbConnection();
+
     // Obtener auxiliares filtrados
     $stmt_items = $pdo->prepare("CALL sp_read_all_auxiliares(?, ?, ?)");
     $stmt_items->execute([$filter_nombre, $filter_num_doc, $filter_tipo_aux]);

--- a/src/pages/sub_proyectos.php
+++ b/src/pages/sub_proyectos.php
@@ -20,6 +20,11 @@ try {
     $proyectos = $stmt_proyectos->fetchAll();
     $stmt_proyectos->closeCursor();
 
+    // Forzar la reconexión. A pesar de las optimizaciones, la conexión sigue fallando
+    // en este punto específico. Esta es la solución más directa para asegurar una conexión viva.
+    $pdo = null;
+    $pdo = getDbConnection();
+
     // Obtener sub proyectos filtrados
     $stmt_items = $pdo->prepare("CALL sp_read_all_sub_proyectos(?, ?, ?)");
     $stmt_items->execute([$filter_codigo, $filter_nombre, $filter_proyecto]);


### PR DESCRIPTION
…nexión.

Después de múltiples intentos con optimizaciones y mejoras en la lógica de conexión central, el error "MySQL server has gone away" persistía en páginas con múltiples consultas.

Este commit implementa la solución más directa y robusta para este caso específico: forzar una reconexión a la base de datos (`$pdo = null; $pdo = getDbConnection();`) entre las consultas en las páginas afectadas (`sub_proyectos.php` y `auxiliares.php`).

Aunque no es la solución más elegante, ha demostrado ser la única efectiva para prevenir el error en este entorno.

Este cambio se suma a las mejoras anteriores (procedimientos almacenados optimizados y una función `getDbConnection` más resiliente), que se mantienen por sus beneficios generales para la aplicación.