### PR TITLE
Fix: Añade reporte de errores para el formulario de ingreso de docume…

### DIFF
--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -116,7 +116,8 @@ try {
     }
     // Redirigir con mensaje de error
     // En una app real, sería bueno registrar el error $e->getMessage()
-    header('Location: ../../public/index.php?page=ingreso_documentos_form&error=1');
+    $error_message = urlencode($e->getMessage());
+    header('Location: ../../public/index.php?page=ingreso_documentos_form&error=' . $error_message);
     exit();
 }
 ?>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -79,6 +79,12 @@ try {
 </header>
 
 <section class="form-container">
+    <?php if (isset($_GET['error'])): ?>
+        <div style="padding: 15px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; border-radius: 5px; margin-bottom: 20px;">
+            <strong>Error al guardar el documento:</strong><br>
+            <?= htmlspecialchars(urldecode($_GET['error'])) ?>
+        </div>
+    <?php endif; ?>
     <form action="../src/actions/documentos_process.php" method="POST">
         <input type="hidden" name="id_documento" value="<?= htmlspecialchars($documento['id'] ?? '') ?>">
 


### PR DESCRIPTION
…ntos.

El proceso de guardado fallaba silenciosamente, redirigiendo al usuario al formulario sin ninguna explicación.

Este cambio modifica el script de procesamiento para capturar el mensaje de error específico de la base de datos y lo pasa de vuelta al formulario. El formulario ha sido modificado para mostrar este error prominentemente.

El propósito de este cambio es diagnosticar la causa raíz del fallo en el guardado.