### PR TITLE
feat: Update exchange rate logic and fix form bugs

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -487,6 +487,8 @@ document.addEventListener('DOMContentLoaded', function() {
     monedaSelect.addEventListener('change', toggleCurrencyColumns);
     proyectoSelect.addEventListener('change', loadAndSelectSubProyecto);
     btnRefreshTC.addEventListener('click', fetchAndSetTipoCambio);
+    // El cambio de fecha SIEMPRE debe buscar el tipo de cambio, tanto en modo nuevo como en edición.
+    fechaEmisionInput.addEventListener('change', fetchAndSetTipoCambio);
 
     if (documentoData) {
         // MODO EDICIÓN: Cargar datos existentes y configurar UI
@@ -540,7 +542,6 @@ document.addEventListener('DOMContentLoaded', function() {
     } else {
         // MODO NUEVO: Configurar estado inicial y listeners adicionales
         toggleCurrencyColumns();
-        fechaEmisionInput.addEventListener('change', fetchAndSetTipoCambio);
         // Cargar el tipo de cambio para la fecha actual al crear un nuevo documento
         fetchAndSetTipoCambio();
     }


### PR DESCRIPTION
This commit includes several enhancements and bug fixes for the document form:

1.  **Exchange Rate on Date Change:** The exchange rate is now fetched from the API whenever the emission date is changed, in both 'new' and 'edit' modes. This ensures the rate is always current relative to the selected date.

2.  **CORS Error Fix:** A PHP proxy (`src/ajax/get_tipo_cambio.php`) is used for the exchange rate API call, resolving the CORS error that blocked direct client-side requests.

3.  **Sub-Project Dropdown Fix:** The logic for the sub-project dropdown is now asynchronous, fixing a race condition that prevented the saved value from being selected in edit mode.

4.  **Currency Column Display:** The logic to hide/show 'Total Soles' and 'Total Dolares' columns is now more robust, using a CSS class toggle.