### PR TITLE
fix: Prevent 'MySQL server has gone away' error in auxiliares_form

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -22,9 +22,13 @@ try {
         $is_edit = true;
         $item_id = $_GET['id'];
 
+        // Re-establish connection to prevent "MySQL server has gone away" errors on long-running pages
+        $pdo = getDbConnection();
+
         $stmt_item = $pdo->prepare("CALL sp_read_auxiliar_by_id(?)");
         $stmt_item->execute([$item_id]);
         $item = $stmt_item->fetch();
+        $stmt_item->closeCursor();
     }
 } catch (PDOException $e) {
     die("Error al obtener datos: " . $e->getMessage());


### PR DESCRIPTION
This commit resolves a 'MySQL server has gone away' (error 2006) and 'Packets out of order' warning on the `auxiliares_form.php` page.

The error was caused by the database connection timing out between two consecutive stored procedure calls.

The fix involves re-establishing the database connection by calling `getDbConnection()` before the second query is executed. This leverages the existing connection-checking logic in `database.php` to ensure a live connection is used, preventing the error. A `closeCursor()` call was also added for robustness.