### PR TITLE
feat: Add SUNAT RUC lookup to auxiliaries form

### DIFF
--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -13,7 +13,7 @@ $pdo = getDbConnection();
 try {
     switch ($action) {
         case 'create':
-            $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id_tipo_auxiliar'],
                 $_POST['tipo_doc_identidad'],
@@ -21,12 +21,13 @@ try {
                 $_POST['razon_social_nombres'],
                 $_POST['direccion'],
                 $_POST['telefono'],
-                $_POST['email']
+                $_POST['email'],
+                $_POST['ubigeo']
             ]);
             break;
 
         case 'update':
-            $stmt = $pdo->prepare("CALL sp_update_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_update_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id'],
                 $_POST['id_tipo_auxiliar'],
@@ -36,6 +37,7 @@ try {
                 $_POST['direccion'],
                 $_POST['telefono'],
                 $_POST['email'],
+                $_POST['ubigeo'],
                 $_POST['estado']
             ]);
             break;

--- a/src/ajax/get_ruc.php
+++ b/src/ajax/get_ruc.php
@@ -1,0 +1,55 @@
+<?php
+header('Content-Type: application/json');
+
+// 1. Validar el parámetro de número de RUC
+if (!isset($_GET['numero'])) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'El parámetro numero es requerido.']);
+    exit;
+}
+
+$numero_ruc = $_GET['numero'];
+
+// Validar que el RUC tenga 11 dígitos y sea numérico
+if (!preg_match('/^\d{11}$/', $numero_ruc)) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'El número de RUC debe tener 11 dígitos.']);
+    exit;
+}
+
+// 2. Construir la URL de la API externa
+$apiUrl = 'https://api.apis.net.pe/v1/ruc?numero=' . urlencode($numero_ruc);
+
+// 3. Realizar la solicitud a la API externa
+$context = stream_context_create([
+    'http' => [
+        'timeout' => 10,
+        'ignore_errors' => true
+    ]
+]);
+
+$response = @file_get_contents($apiUrl, false, $context);
+
+// 4. Manejar la respuesta
+if ($response === false) {
+    http_response_code(502); // Bad Gateway
+    echo json_encode(['error' => 'No se pudo conectar con la API de consulta RUC.']);
+    exit;
+}
+
+// Intentar decodificar para verificar si es un JSON válido
+$data = json_decode($response);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    http_response_code(502); // Bad Gateway
+    echo json_encode(['error' => 'La respuesta de la API externa no es un JSON válido.']);
+    exit;
+}
+
+// Si la API externa devolvió un error (por ejemplo, 404, 500), lo reflejamos.
+if (strpos($http_response_header[0], '200 OK') === false) {
+    sscanf($http_response_header[0], 'HTTP/%*d.%*d %d', $http_status_code);
+    http_response_code($http_status_code ?? 500);
+}
+
+// 5. Devolver la respuesta de la API al cliente
+echo $response;

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -76,7 +76,10 @@ try {
         </div>
         <div class="form-group">
             <label for="num_doc_identidad">Número Documento</label>
-            <input type="text" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($item['num_doc_identidad'] ?? '') ?>" required>
+            <div style="display: flex; align-items: center;">
+                <input type="text" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($item['num_doc_identidad'] ?? '') ?>" required style="flex-grow: 1;">
+                <button type="button" id="btn-sunat" class="btn-submit" style="margin-left: 10px; flex-shrink: 0;">SUNAT</button>
+            </div>
         </div>
         <div class="form-group">
             <label for="razon_social_nombres">Razón Social / Nombres</label>
@@ -94,6 +97,10 @@ try {
             <label for="email">Email</label>
             <input type="email" id="email" name="email" value="<?= htmlspecialchars($item['email'] ?? '') ?>">
         </div>
+        <div class="form-group">
+            <label for="ubigeo">Ubigeo</label>
+            <input type="text" id="ubigeo" name="ubigeo" value="<?= htmlspecialchars($item['ubigeo'] ?? '') ?>" maxlength="6">
+        </div>
         <?php if ($is_edit): ?>
         <div class="form-group">
             <label for="estado">Estado</label>
@@ -107,3 +114,69 @@ try {
         <button type="submit" class="btn-submit"><?= $is_edit ? 'Actualizar' : 'Crear' ?> Auxiliar</button>
     </form>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btnSunat = document.getElementById('btn-sunat');
+    if (btnSunat) {
+        btnSunat.addEventListener('click', async function() {
+            const tipoDocSelect = document.getElementById('tipo_doc_identidad');
+            const numDocInput = document.getElementById('num_doc_identidad');
+
+            if (tipoDocSelect.value !== 'RUC') {
+                alert('Esta función solo está disponible para el tipo de documento RUC.');
+                return;
+            }
+
+            const ruc = numDocInput.value;
+            if (!/^\d{11}$/.test(ruc)) {
+                alert('Por favor, ingrese un número de RUC válido de 11 dígitos.');
+                return;
+            }
+
+            // Deshabilitar botón para evitar clics múltiples
+            this.disabled = true;
+            this.textContent = 'Buscando...';
+
+            try {
+                const response = await fetch(`../src/ajax/get_ruc.php?numero=${ruc}`);
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => null);
+                    throw new Error(errorData?.error || 'No se pudo obtener una respuesta de la API.');
+                }
+
+                const data = await response.json();
+                if (data.error) {
+                    throw new Error(data.error);
+                }
+
+                // Poblar los campos del formulario
+                const razonSocialInput = document.getElementById('razon_social_nombres');
+                const direccionInput = document.getElementById('direccion');
+                const ubigeoInput = document.getElementById('ubigeo');
+
+                if (razonSocialInput && data.nombre) {
+                    razonSocialInput.value = data.nombre;
+                }
+                if (direccionInput && data.direccion) {
+                    let fullDireccion = [data.direccion, data.departamento, data.provincia, data.distrito]
+                        .filter(Boolean) // Filtrar valores nulos o vacíos
+                        .join(' - ');
+                    direccionInput.value = fullDireccion;
+                }
+                if (ubigeoInput && data.ubigeo) {
+                    ubigeoInput.value = data.ubigeo;
+                }
+
+            } catch (error) {
+                console.error('Error al consultar SUNAT:', error);
+                alert(`Error al consultar SUNAT: ${error.message}`);
+            } finally {
+                // Rehabilitar el botón
+                this.disabled = false;
+                this.textContent = 'SUNAT';
+            }
+        });
+    }
+});
+</script>


### PR DESCRIPTION
This commit implements a new feature on the 'Auxiliares' form to automatically populate fields by looking up a RUC from an external API.

- Adds a 'Sunat' button to the form UI.
- Adds a new 'Ubigeo' field to the form.
- Creates a new PHP proxy (`src/ajax/get_ruc.php`) to handle the API call to `api.apis.net.pe` and avoid CORS errors.
- Implements frontend JavaScript to trigger the API call on button click and populate the 'Razón Social / Nombres', 'Dirección', and 'Ubigeo' fields from the response.
- Updates the backend action (`src/actions/auxiliares_process.php`) to save the new 'ubigeo' field to the database. The user has been provided with the necessary SQL to update their database schema and stored procedures.