### PR TITLE
feat: Add maintenance for Tipos de Documento and JS validation

### DIFF
--- a/database/patch_add_longitud_tipos_documento.sql
+++ b/database/patch_add_longitud_tipos_documento.sql
@@ -1,0 +1,79 @@
+-- =================================================================
+-- Patch para añadir la columna `longitud` a `tipos_documento`
+-- y actualizar los procedimientos almacenados correspondientes.
+-- Fecha: 2025-09-07
+-- =================================================================
+
+-- 1. Añadir la columna `longitud` a la tabla `tipos_documento`
+ALTER TABLE `tipos_documento` ADD COLUMN `longitud` INT NULL AFTER `descripcion`;
+
+-- 2. Actualizar los procedimientos almacenados
+
+-- sp_create_tipo_documento
+DROP PROCEDURE IF EXISTS sp_create_tipo_documento;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_tipo_documento`(
+    IN p_codigo VARCHAR(10),
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_longitud INT
+)
+BEGIN
+    INSERT INTO tipos_documento (codigo, nombre, descripcion, longitud)
+    VALUES (p_codigo, p_nombre, p_descripcion, p_longitud);
+END$$
+DELIMITER ;
+
+-- sp_update_tipo_documento
+DROP PROCEDURE IF EXISTS sp_update_tipo_documento;
+DELIMITER $$
+CREATE PROCEDURE `sp_update_tipo_documento`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_longitud INT,
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE tipos_documento
+    SET
+        nombre = p_nombre,
+        descripcion = p_descripcion,
+        longitud = p_longitud,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- sp_read_all_tipos_documento
+DROP PROCEDURE IF EXISTS sp_read_all_tipos_documento;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_tipos_documento`(
+    IN p_codigo VARCHAR(10),
+    IN p_nombre VARCHAR(100)
+)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, longitud, estado FROM tipos_documento
+    WHERE
+        (p_codigo IS NULL OR p_codigo = '' OR codigo LIKE CONCAT('%', p_codigo, '%'))
+        AND (p_nombre IS NULL OR p_nombre = '' OR nombre LIKE CONCAT('%', p_nombre, '%'));
+END$$
+DELIMITER ;
+
+-- sp_read_tipo_documento_by_id
+DROP PROCEDURE IF EXISTS sp_read_tipo_documento_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_tipo_documento_by_id`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, longitud, estado FROM tipos_documento WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- sp_read_tipo_documento_longitud_by_id
+DROP PROCEDURE IF EXISTS sp_read_tipo_documento_longitud_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_tipo_documento_longitud_by_id`(IN p_id INT)
+BEGIN
+    SELECT longitud FROM tipos_documento WHERE id = p_id;
+END$$
+DELIMITER ;

--- a/src/actions/tipos_documento_process.php
+++ b/src/actions/tipos_documento_process.php
@@ -13,20 +13,22 @@ $pdo = getDbConnection();
 try {
     switch ($action) {
         case 'create':
-            $stmt = $pdo->prepare("CALL sp_create_tipo_documento(?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_create_tipo_documento(?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['codigo'],
                 $_POST['nombre'],
-                $_POST['descripcion']
+                $_POST['descripcion'],
+                $_POST['longitud']
             ]);
             break;
 
         case 'update':
-            $stmt = $pdo->prepare("CALL sp_update_tipo_documento(?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_update_tipo_documento(?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id'],
                 $_POST['nombre'],
                 $_POST['descripcion'],
+                $_POST['longitud'],
                 $_POST['estado']
             ]);
             break;

--- a/src/ajax/get_tipo_documento_longitud.php
+++ b/src/ajax/get_tipo_documento_longitud.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_GET['id'])) {
+    echo json_encode(['error' => 'No se proporcionó el ID del tipo de documento.']);
+    http_response_code(400);
+    exit;
+}
+
+$id_tipo_documento = $_GET['id'];
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_read_tipo_documento_longitud_by_id(?)");
+    $stmt->execute([$id_tipo_documento]);
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($result) {
+        echo json_encode($result);
+    } else {
+        echo json_encode(['error' => 'Tipo de documento no encontrado.']);
+        http_response_code(404);
+    }
+} catch (PDOException $e) {
+    echo json_encode(['error' => 'Error en la base de datos: ' . $e->getMessage()]);
+    http_response_code(500);
+}
+?>

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -25,8 +25,8 @@
                             <li><a href="index.php?page=proyectos">Proyectos</a></li>
                             <li><a href="index.php?page=sub_proyectos">Sub Proyectos</a></li>
                             <li><a href="index.php?page=centros_costos">Centros de Costos</a></li>
-                            <li><a href="index.php?page=tipos_documento">Tipos de Documento</a></li>
                             <li><a href="index.php?page=conceptos">Conceptos</a></li>
+                            <li><a href="index.php?page=tipos_documento">Tipos de Documento</a></li>
                             <li><a href="index.php?page=tipos_auxiliar">Tipos de Auxiliar</a></li>
                             <li><a href="index.php?page=usuarios">Usuarios</a></li>
                             <li><a href="index.php?page=tipos_cambio">Tipo de Cambio</a></li>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -273,6 +273,30 @@ document.addEventListener('DOMContentLoaded', function() {
     const numeroDocumentoInput = document.getElementById('numero_documento');
     const detailsTbody = document.getElementById('details-tbody');
     const btnAddRow = document.getElementById('btn-add-row');
+    const tipoDocumentoSelect = document.getElementById('id_tipo_documento');
+
+    async function updateNumeroDocumentoLength() {
+        const tipoDocId = tipoDocumentoSelect.value;
+
+        numeroDocumentoInput.value = '';
+        numeroDocumentoInput.removeAttribute('maxlength');
+
+        if (!tipoDocId) return;
+
+        try {
+            const response = await fetch(`../src/ajax/get_tipo_documento_longitud.php?id=${tipoDocId}`);
+            if (!response.ok) return;
+
+            const data = await response.json();
+            if (data && data.longitud && data.longitud > 0) {
+                numeroDocumentoInput.maxLength = data.longitud;
+            }
+        } catch (error) {
+            console.error('Error al obtener la longitud del tipo de documento:', error);
+        }
+    }
+
+    tipoDocumentoSelect.addEventListener('change', updateNumeroDocumentoLength);
 
     // Padrón de ceros a la izquierda para el número de documento
     numeroDocumentoInput.addEventListener('blur', function() {

--- a/src/pages/tipos_documento.php
+++ b/src/pages/tipos_documento.php
@@ -62,6 +62,7 @@ try {
                 <th>Código</th>
                 <th>Nombre</th>
                 <th>Descripción</th>
+                <th>Longitud</th>
                 <th>Estado</th>
                 <th>Acciones</th>
             </tr>
@@ -73,6 +74,7 @@ try {
                 <td><?= htmlspecialchars($item['codigo']) ?></td>
                 <td><?= htmlspecialchars($item['nombre']) ?></td>
                 <td><?= htmlspecialchars($item['descripcion']) ?></td>
+                <td><?= htmlspecialchars($item['longitud']) ?></td>
                 <td><?= $item['estado'] ? 'Activo' : 'Inactivo' ?></td>
                 <td>
                     <a href="index.php?page=tipos_documento_form&id=<?= $item['id'] ?>" class="btn btn-edit">Editar</a>

--- a/src/pages/tipos_documento_form.php
+++ b/src/pages/tipos_documento_form.php
@@ -54,6 +54,10 @@ if (isset($_GET['id'])) {
             <label for="descripcion">Descripción</label>
             <textarea id="descripcion" name="descripcion" rows="3"><?= htmlspecialchars($item['descripcion'] ?? '') ?></textarea>
         </div>
+        <div class="form-group">
+            <label for="longitud">Longitud</label>
+            <input type="number" id="longitud" name="longitud" value="<?= htmlspecialchars($item['longitud'] ?? '') ?>">
+        </div>
         <?php if ($is_edit): ?>
         <div class="form-group">
             <label for="estado">Estado</label>


### PR DESCRIPTION
- Adds a new maintenance page for 'Tipos de Documento' with full CRUD functionality.
- Includes a 'longitud' field to store the required length for each document type.
- Creates a new SQL patch file for the database changes, including new stored procedures.
- Implements JavaScript validation on the document entry form to restrict the length of the document number based on the selected document type.
- Updates the navigation menu to include the new maintenance page in the correct location.