### PR TITLE
feat: Add Identity Document Type module and fix related bugs

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -145,31 +145,40 @@ document.addEventListener('DOMContentLoaded', function() {
 
     async function updateDocumentLength() {
         const selectedId = tipoDocSelect.value;
-        numDocInput.removeAttribute('maxlength');
-
-        if (!selectedId) return;
+        // No limpiar el maxlength aquí, solo quitarlo si no hay tipo
+        if (!selectedId) {
+            numDocInput.removeAttribute('maxlength');
+            return;
+        }
 
         try {
             const response = await fetch(`../src/ajax/get_tipo_documento_identidad_longitud.php?id=${selectedId}`);
-            if (!response.ok) return;
+            if (!response.ok) {
+                numDocInput.removeAttribute('maxlength');
+                return;
+            }
 
             const data = await response.json();
             if (data && data.longitud && data.longitud > 0) {
                 numDocInput.maxLength = data.longitud;
+            } else {
+                numDocInput.removeAttribute('maxlength');
             }
         } catch (error) {
             console.error('Error al obtener la longitud del tipo de documento:', error);
+            numDocInput.removeAttribute('maxlength');
         }
     }
 
     // --- Event Listeners ---
     tipoDocSelect.addEventListener('change', function() {
-        numDocInput.value = ''; // Limpiar el valor solo en el cambio manual
+        numDocInput.value = ''; // Limpiar el valor del número solo en el cambio manual
         updateSunatButtonVisibility();
         updateDocumentLength();
     });
 
     // --- Carga Inicial ---
+    // Llamar a las funciones para establecer el estado inicial de la página
     updateSunatButtonVisibility();
     updateDocumentLength();
 


### PR DESCRIPTION
This change introduces a new maintenance module for 'Tipos de Documento de Identidad' and fixes bugs in the 'Auxiliares' form that were introduced during development.

- Creates a new CRUD maintenance module for 'Tipos de Documento de Identidad', including a 'longitud' field.
- Creates a new SQL patch file for all related database changes.
- Refactors the 'Auxiliares' form to use a dynamic dropdown for identity document types.
- Implements JavaScript validation on the 'Auxiliares' form for document length and SUNAT button visibility.
- Fixes a bug where the 'Auxiliares' edit form did not correctly load saved data.
- Fixes a bug where the SUNAT button on the 'Auxiliares' form was not working.