### PR TITLE
fix: Correct SQL patch to ensure table alteration is executed

### DIFF
--- a/database/patch_add_tipos_documento_identidad.sql
+++ b/database/patch_add_tipos_documento_identidad.sql
@@ -109,8 +109,8 @@ END$$
 DELIMITER ;
 
 -- Es recomendable ejecutar este procedimiento manualmente después de poblar la tabla `tipos_documento_identidad`.
--- CALL patch_modify_auxiliares_for_identity_docs();
--- DROP PROCEDURE patch_modify_auxiliares_for_identity_docs;
+CALL patch_modify_auxiliares_for_identity_docs();
+DROP PROCEDURE patch_modify_auxiliares_for_identity_docs;
 
 
 -- 4. SP para leer los tipos de documento de identidad en un dropdown


### PR DESCRIPTION
This commit fixes the root cause of the persistent bug in the 'Auxiliares' edit form.

- The patch file `database/patch_add_tipos_documento_identidad.sql` has been corrected to uncomment the `CALL` statement.
- This ensures that the procedure to alter the `auxiliares` table is actually executed, which modifies the schema to use the new `id_tipo_documento_identidad` foreign key.
- This schema change allows the form to correctly load saved data and the update process to function as intended.