### PR TITLE
fix: Correctly display document type in Auxiliares list view

### DIFF
--- a/database/full_setup.sql
+++ b/database/full_setup.sql
@@ -664,9 +664,19 @@ CREATE PROCEDURE `sp_read_all_auxiliares`(
     IN p_tipo_aux INT
 )
 BEGIN
-    SELECT a.*, ta.nombre as nombre_tipo_auxiliar
+    SELECT
+        a.id,
+        a.razon_social_nombres,
+        a.num_doc_identidad,
+        a.direccion,
+        a.telefono,
+        a.email,
+        a.estado,
+        ta.nombre as nombre_tipo_auxiliar,
+        tdi.nombre as tipo_doc_identidad
     FROM auxiliares a
     JOIN tipos_auxiliar ta ON a.id_tipo_auxiliar = ta.id
+    LEFT JOIN tipos_documento_identidad tdi ON a.id_tipo_documento_identidad = tdi.id
     WHERE
         (p_nombre IS NULL OR p_nombre = '' OR a.razon_social_nombres LIKE CONCAT('%', p_nombre, '%'))
         AND (p_num_doc IS NULL OR p_num_doc = '' OR a.num_doc_identidad LIKE CONCAT('%', p_num_doc, '%'))

--- a/src/pages/auxiliares.php
+++ b/src/pages/auxiliares.php
@@ -99,7 +99,13 @@ try {
             <tr>
                 <td><?= htmlspecialchars($item['id']) ?></td>
                 <td><?= htmlspecialchars($item['nombre_tipo_auxiliar']) ?></td>
-                <td><?= htmlspecialchars($item['tipo_doc_identidad'] . ' ' . $item['num_doc_identidad']) ?></td>
+                <td>
+                    <?php
+                        $doc_type = $item['tipo_doc_identidad'] ?? '';
+                        $doc_num = $item['num_doc_identidad'] ?? '';
+                        echo htmlspecialchars(trim($doc_type . ' ' . $doc_num));
+                    ?>
+                </td>
                 <td><?= htmlspecialchars($item['razon_social_nombres']) ?></td>
                 <td><?= htmlspecialchars($item['email']) ?></td>
                 <td><?= htmlspecialchars($item['telefono']) ?></td>


### PR DESCRIPTION
This commit fixes a bug that caused an "Undefined index" error on the main 'Auxiliares' listing page.

- The `sp_read_all_auxiliares` stored procedure has been updated to JOIN with the `tipos_documento_identidad` table, ensuring the document type name is returned.
- The `auxiliares.php` page has been made more robust to prevent errors if the document type is missing for any reason.