### PR TITLE
feat: Implement conditional hard delete for Auxiliares

### DIFF
--- a/database/full_setup.sql
+++ b/database/full_setup.sql
@@ -713,7 +713,19 @@ DROP PROCEDURE IF EXISTS sp_delete_auxiliar;
 DELIMITER $$
 CREATE PROCEDURE `sp_delete_auxiliar`(IN p_id INT)
 BEGIN
-    UPDATE auxiliares SET estado = FALSE WHERE id = p_id;
+    DECLARE doc_count INT;
+
+    -- Verificar si existen documentos asociados
+    SELECT COUNT(*) INTO doc_count FROM documentos WHERE id_auxiliar = p_id;
+
+    IF doc_count > 0 THEN
+        -- Si hay documentos, no se puede eliminar. Devolver un status.
+        SELECT 'HAS_DOCS' AS status;
+    ELSE
+        -- Si no hay documentos, eliminar permanentemente.
+        DELETE FROM auxiliares WHERE id = p_id;
+        SELECT 'DELETED' AS status;
+    END IF;
 END$$
 DELIMITER ;
 

--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -45,6 +45,13 @@ try {
         case 'delete':
             $stmt = $pdo->prepare("CALL sp_delete_auxiliar(?)");
             $stmt->execute([$_GET['id']]);
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($result['status'] === 'HAS_DOCS') {
+                header('Location: ../../public/index.php?page=auxiliares&error=delete_failed_has_docs');
+                exit();
+            }
+            // Si es 'DELETED', la redirección de éxito al final del script se encargará.
             break;
 
         default:

--- a/src/pages/auxiliares.php
+++ b/src/pages/auxiliares.php
@@ -55,6 +55,11 @@ try {
     <h1>Mantenimiento de Auxiliares</h1>
 </header>
 <section>
+    <?php if (isset($_GET['error']) && $_GET['error'] === 'delete_failed_has_docs'): ?>
+        <script>
+            alert('No se puede eliminar el auxiliar porque tiene documentos asociados.');
+        </script>
+    <?php endif; ?>
     <a href="index.php?page=auxiliares_form" class="btn btn-add">Añadir Nuevo Auxiliar</a>
 
     <form action="index.php" method="GET" class="filter-form">


### PR DESCRIPTION
This commit changes the delete behavior for the 'Auxiliares' module.

- The 'delete' operation is now a conditional hard delete instead of a soft delete.
- The `sp_delete_auxiliar` stored procedure now checks for associated records in the `documentos` table.
- If an 'Auxiliar' has associated documents, the deletion is blocked, and an alert is shown to the user on the frontend.
- If an 'Auxiliar' has no associated documents, it is permanently deleted from the database.
- The backend process and frontend page have been updated to support this new workflow.