### PR TITLE
feat: Add Identity Document Type module and all related fixes

### DIFF
--- a/database/full_setup.sql
+++ b/database/full_setup.sql
@@ -647,11 +647,12 @@ CREATE PROCEDURE `sp_create_auxiliar`(
     IN p_razon_social_nombres VARCHAR(255),
     IN p_direccion VARCHAR(255),
     IN p_telefono VARCHAR(50),
-    IN p_email VARCHAR(100)
+    IN p_email VARCHAR(100),
+    IN p_ubigeo VARCHAR(6)
 )
 BEGIN
-    INSERT INTO auxiliares (id_tipo_auxiliar, tipo_doc_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email)
-    VALUES (p_id_tipo_auxiliar, p_tipo_doc_identidad, p_num_doc_identidad, p_razon_social_nombres, p_direccion, p_telefono, p_email);
+    INSERT INTO auxiliares (id_tipo_auxiliar, id_tipo_documento_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email, ubigeo)
+    VALUES (p_id_tipo_auxiliar, p_id_tipo_documento_identidad, p_num_doc_identidad, p_razon_social_nombres, p_direccion, p_telefono, p_email, p_ubigeo);
 END$$
 DELIMITER ;
 
@@ -692,6 +693,7 @@ CREATE PROCEDURE `sp_update_auxiliar`(
     IN p_direccion VARCHAR(255),
     IN p_telefono VARCHAR(50),
     IN p_email VARCHAR(100),
+    IN p_ubigeo VARCHAR(6),
     IN p_estado BOOLEAN
 )
 BEGIN
@@ -704,6 +706,7 @@ BEGIN
         direccion = p_direccion,
         telefono = p_telefono,
         email = p_email,
+        ubigeo = p_ubigeo,
         estado = p_estado
     WHERE id = p_id;
 END$$

--- a/database/patch_fix_auxiliar_sps.sql
+++ b/database/patch_fix_auxiliar_sps.sql
@@ -1,0 +1,58 @@
+-- =================================================================
+-- Script de Corrección Final para los SPs de Auxiliares
+-- Fecha: 2025-09-07
+-- Autor: Jules AI
+-- Descripción: Este script corrige los procedimientos almacenados
+-- para crear y actualizar auxiliares, asegurando que acepten
+-- el parámetro `ubigeo`.
+-- =================================================================
+
+-- Corregir sp_create_auxiliar
+DROP PROCEDURE IF EXISTS sp_create_auxiliar;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_auxiliar`(
+    IN p_id_tipo_auxiliar INT,
+    IN p_id_tipo_documento_identidad INT,
+    IN p_num_doc_identidad VARCHAR(20),
+    IN p_razon_social_nombres VARCHAR(255),
+    IN p_direccion VARCHAR(255),
+    IN p_telefono VARCHAR(50),
+    IN p_email VARCHAR(100),
+    IN p_ubigeo VARCHAR(6)
+)
+BEGIN
+    INSERT INTO auxiliares (id_tipo_auxiliar, id_tipo_documento_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email, ubigeo)
+    VALUES (p_id_tipo_auxiliar, p_id_tipo_documento_identidad, p_num_doc_identidad, p_razon_social_nombres, p_direccion, p_telefono, p_email, p_ubigeo);
+END$$
+DELIMITER ;
+
+-- Corregir sp_update_auxiliar
+DROP PROCEDURE IF EXISTS sp_update_auxiliar;
+DELIMITER $$
+CREATE PROCEDURE `sp_update_auxiliar`(
+    IN p_id INT,
+    IN p_id_tipo_auxiliar INT,
+    IN p_id_tipo_documento_identidad INT,
+    IN p_num_doc_identidad VARCHAR(20),
+    IN p_razon_social_nombres VARCHAR(255),
+    IN p_direccion VARCHAR(255),
+    IN p_telefono VARCHAR(50),
+    IN p_email VARCHAR(100),
+    IN p_ubigeo VARCHAR(6),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE auxiliares
+    SET
+        id_tipo_auxiliar = p_id_tipo_auxiliar,
+        id_tipo_documento_identidad = p_id_tipo_documento_identidad,
+        num_doc_identidad = p_num_doc_identidad,
+        razon_social_nombres = p_razon_social_nombres,
+        direccion = p_direccion,
+        telefono = p_telefono,
+        email = p_email,
+        ubigeo = p_ubigeo,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+DELIMITER ;


### PR DESCRIPTION
This commit delivers the complete 'Tipos de Documento de Identidad' feature and provides a definitive set of fixes for all related bugs reported during development, including create, edit, list, and delete functionality for the 'Auxiliares' module.

- Creates a new CRUD maintenance module for 'Tipos de Documento de Identidad'.
- Provides a series of SQL patch files to create the new table, safely alter the 'auxiliares' table, add the missing 'ubigeo' column, and correct all related stored procedures.
- Refactors the 'Auxiliares' form to use a dynamic dropdown for identity document types and ensures all data loads and saves correctly.
- Implements and fixes JavaScript validation on the 'Auxiliares' form for document length and SUNAT button functionality.
- Implements a conditional hard-delete for 'Auxiliares', preventing deletion if associated documents exist.
- Fixes all previously reported bugs, including the 'Undefined index' error in the list view and the 'Incorrect number of arguments' error during creation.