### PR TITLE
fix: Add server-side validation for Auxiliar creation/update

### DIFF
--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -11,6 +11,15 @@ $action = $_REQUEST['action'] ?? null;
 $pdo = getDbConnection();
 
 try {
+    // Validación del Tipo de Documento de Identidad para crear y actualizar
+    if ($action === 'create' || $action === 'update') {
+        if (empty($_POST['id_tipo_documento_identidad']) || !is_numeric($_POST['id_tipo_documento_identidad'])) {
+            $form_page = $action === 'create' ? 'auxiliares_form' : 'auxiliares_form&id=' . $_POST['id'];
+            header('Location: ../../public/index.php?page=' . $form_page . '&error=invalid_doc_type');
+            exit();
+        }
+    }
+
     switch ($action) {
         case 'create':
             $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?, ?)");

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -56,6 +56,11 @@ try {
     <h1><?= $is_edit ? 'Editar' : 'Añadir' ?> Auxiliar</h1>
 </header>
 <section class="form-container">
+    <?php if (isset($_GET['error']) && $_GET['error'] === 'invalid_doc_type'): ?>
+        <div style="padding: 15px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; border-radius: 5px; margin-bottom: 20px;">
+            <strong>Error:</strong> Por favor, seleccione un Tipo de Documento de Identidad válido.
+        </div>
+    <?php endif; ?>
     <form action="../src/actions/auxiliares_process.php" method="POST">
         <input type="hidden" name="action" value="<?= $is_edit ? 'update' : 'create' ?>">
         <?php if ($is_edit): ?>


### PR DESCRIPTION
This commit adds server-side validation to the 'auxiliares_process.php' script to prevent records from being saved without a valid identity document type.

- The script now checks if `id_tipo_documento_identidad` is empty or non-numeric before proceeding.
- If the validation fails, it redirects back to the form with a user-friendly error message.
- This resolves the bug where `id_tipo_documento_identidad` was being saved as NULL in the database.