### PR TITLE
feat: Add temporary debugging to diagnose creation error

### DIFF
--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -64,10 +64,13 @@ try {
     header('Location: ../../public/index.php?page=auxiliares&success=Operación realizada con éxito');
 
 } catch (PDOException $e) {
-    if ($e->getCode() == 23000) {
-        header('Location: ../../public/index.php?page=auxiliares&error=Error: El número de documento ya existe.');
-    } else {
-        header('Location: ../../public/index.php?page=auxiliares&error=Error en la base de datos: ' . $e->getMessage());
-    }
+    // --- DEBUGGING ---
+    // Modificado para mostrar siempre el error real de la base de datos.
+    $error_message = "Error Detallado de la Base de Datos: " . $e->getMessage() .
+                     " (Código: " . $e->getCode() . ")" .
+                     " | En Archivo: " . $e->getFile() . " Línea: " . $e->getLine();
+
+    // Para asegurar que el mensaje se vea, lo mostramos directamente.
+    die('<pre>' . htmlspecialchars($error_message) . '</pre>');
 }
 ?>


### PR DESCRIPTION
This commit adds temporary debugging code to the `auxiliares_process.php` script.

- The `try...catch` block has been modified to output the full, detailed PDOException message instead of a generic error.
- This is intended to help diagnose a persistent bug where creating a new 'Auxiliar' fails with an integrity constraint violation.