### PR TITLE
refactor: Adjust form layout for labels

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -141,31 +141,31 @@ try {
                 </div>
             </div>
 
-            <div class="form-group" style="margin-top: 20px; display: flex; flex-direction: row; align-items: flex-end;">
-                <div style="flex-grow: 1;">
-                    <label for="id_auxiliar">Auxiliar (Proveedor/Cliente)</label>
-                    <select id="id_auxiliar" name="id_auxiliar" required>
+            <div class="form-group" style="margin-top: 20px;">
+                <label for="id_auxiliar">Auxiliar (Proveedor/Cliente)</label>
+                <div style="display: flex; align-items: center;">
+                    <select id="id_auxiliar" name="id_auxiliar" required style="flex-grow: 1;">
                         <option value="">Seleccione...</option>
                         <?php foreach($auxiliares as $aux): ?>
                             <option value="<?= $aux['id'] ?>"><?= htmlspecialchars($aux['nombre']) ?></option>
                         <?php endforeach; ?>
                     </select>
+                    <button type="button" class="btn-refresh" data-target="id_auxiliar" data-source="../src/ajax/get_auxiliares.php" style="margin-left: 5px; height: 38px;">&#x21bb;</button>
                 </div>
-                <button type="button" class="btn-refresh" data-target="id_auxiliar" data-source="../src/ajax/get_auxiliares.php" style="margin-left: 5px; height: 38px;">&#x21bb;</button>
             </div>
 
              <div class="form-grid" style="margin-top: 20px;">
-                 <div class="form-group" style="display: flex; flex-direction: row; align-items: flex-end;">
-                    <div style="flex-grow: 1;">
-                        <label for="id_proyecto">Proyecto</label>
-                        <select id="id_proyecto" name="id_proyecto" required>
+                <div class="form-group">
+                    <label for="id_proyecto">Proyecto</label>
+                    <div style="display: flex; align-items: center;">
+                        <select id="id_proyecto" name="id_proyecto" required style="flex-grow: 1;">
                             <option value="">Seleccione...</option>
                             <?php foreach($proyectos as $proy): ?>
                                 <option value="<?= $proy['id'] ?>"><?= htmlspecialchars($proy['nombre']) ?></option>
                             <?php endforeach; ?>
                         </select>
+                        <button type="button" class="btn-refresh" data-target="id_proyecto" data-source="../src/ajax/get_proyectos.php" style="margin-left: 5px; height: 38px;">&#x21bb;</button>
                     </div>
-                    <button type="button" class="btn-refresh" data-target="id_proyecto" data-source="../src/ajax/get_proyectos.php" style="margin-left: 5px; height: 38px;">&#x21bb;</button>
                 </div>
                 <div class="form-group" style="display: flex; flex-direction: row; align-items: flex-end;">
                     <div style="flex-grow: 1;">


### PR DESCRIPTION
This commit refactors the layout of the `ingreso_documentos_form.php` page to improve label placement.

- The HTML structure for the 'Proyecto' and 'Auxiliar' fields has been changed.
- The <label> for these fields now appears on its own line, directly above the corresponding <select> element.
- This improves readability and consistency with other fields on the form.