### PR TITLE
feat: Use local DB for exchange rate and add validation

### DIFF
--- a/database/patch_add_sp_read_tc_by_fecha.sql
+++ b/database/patch_add_sp_read_tc_by_fecha.sql
@@ -1,0 +1,19 @@
+-- =================================================================
+-- Patch para añadir el SP `sp_read_tipo_cambio_by_fecha`
+-- Fecha: 2025-09-08
+-- Autor: Jules AI
+-- Descripción: Este script añade un nuevo procedimiento almacenado
+-- para buscar un tipo de cambio por una fecha específica.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_tipo_cambio_by_fecha;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_tipo_cambio_by_fecha`(
+    IN p_fecha DATE
+)
+BEGIN
+    SELECT compra, venta
+    FROM tipos_cambio
+    WHERE fecha = p_fecha;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -11,6 +11,18 @@ $action = $_REQUEST['action'] ?? null;
 $pdo = getDbConnection();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Validación de Tipo de Cambio
+    $tipo_cambio_val = isset($_POST['tipo_cambio']) ? (float)$_POST['tipo_cambio'] : 0;
+    if ($tipo_cambio_val <= 0) {
+        $id_documento = $_POST['id_documento'] ?? null;
+        $redirect_url = '../../public/index.php?page=ingreso_documentos_form&error=tipo_cambio_zero';
+        if (!empty($id_documento)) {
+            $redirect_url .= '&id=' . $id_documento;
+        }
+        header('Location: ' . $redirect_url);
+        exit();
+    }
+
     // Lógica para CREATE y UPDATE
     // --- Obtener datos del formulario ---
     $id_tipo_documento = $_POST['id_tipo_documento'];

--- a/src/ajax/get_tipo_cambio.php
+++ b/src/ajax/get_tipo_cambio.php
@@ -1,58 +1,40 @@
 <?php
+require_once __DIR__ . '/../database.php';
+
 header('Content-Type: application/json');
 
-// 1. Validar el parámetro de fecha
 if (!isset($_GET['fecha'])) {
-    http_response_code(400); // Bad Request
-    echo json_encode(['error' => 'El parámetro fecha es requerido.']);
+    http_response_code(400);
+    echo json_encode(['error' => 'No se proporcionó la fecha.']);
     exit;
 }
 
 $fecha = $_GET['fecha'];
 
-// Expresión regular para validar el formato YYYY-MM-DD
-if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $fecha)) {
-    http_response_code(400); // Bad Request
-    echo json_encode(['error' => 'El formato de la fecha debe ser YYYY-MM-DD.']);
-    exit;
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_read_tipo_cambio_by_fecha(?)");
+    $stmt->execute([$fecha]);
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($result) {
+        // Encontrado en la base de datos local
+        echo json_encode([
+            'compra' => (float)$result['compra'],
+            'venta' => (float)$result['venta'],
+            'origen' => 'LOCAL'
+        ]);
+    } else {
+        // No encontrado, devolver 0.00
+        echo json_encode([
+            'compra' => 0.00,
+            'venta' => 0.00,
+            'origen' => 'NO_ENCONTRADO'
+        ]);
+    }
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error en la base de datos: ' . $e->getMessage()]);
 }
-
-// 2. Construir la URL de la API externa
-$apiUrl = 'https://api.apis.net.pe/v1/tipo-cambio-sunat?fecha=' . urlencode($fecha);
-
-// 3. Realizar la solicitud a la API externa
-// Usar un contexto de stream para manejar errores y timeouts
-$context = stream_context_create([
-    'http' => [
-        'timeout' => 10, // 10 segundos de timeout
-        'ignore_errors' => true // Permite leer el cuerpo de la respuesta incluso si hay un error HTTP
-    ]
-]);
-
-$response = @file_get_contents($apiUrl, false, $context);
-
-// 4. Manejar la respuesta
-if ($response === false) {
-    http_response_code(502); // Bad Gateway
-    echo json_encode(['error' => 'No se pudo conectar con la API de tipo de cambio.']);
-    exit;
-}
-
-// Intentar decodificar para verificar si es un JSON válido, aunque lo pasaremos tal cual
-$data = json_decode($response);
-if (json_last_error() !== JSON_ERROR_NONE) {
-    http_response_code(502); // Bad Gateway
-    echo json_encode(['error' => 'La respuesta de la API externa no es un JSON válido.']);
-    exit;
-}
-
-// Si la API externa devolvió un error (por ejemplo, 404, 500), lo reflejamos.
-// $http_response_header es una variable mágica que se llena con los encabezados de la última respuesta HTTP.
-if (strpos($http_response_header[0], '200 OK') === false) {
-    // Intentamos obtener el código de estado real
-    sscanf($http_response_header[0], 'HTTP/%*d.%*d %d', $http_status_code);
-    http_response_code($http_status_code ?? 500);
-}
-
-// 5. Devolver la respuesta de la API al cliente
-echo $response;
+?>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -92,7 +92,11 @@ try {
 </header>
 
 <section class="form-container">
-    <?php if (isset($_GET['error'])): ?>
+    <?php if (isset($_GET['error']) && $_GET['error'] === 'tipo_cambio_zero'): ?>
+        <div style="padding: 15px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; border-radius: 5px; margin-bottom: 20px;">
+            <strong>Error:</strong> El tipo de cambio debe ser mayor a cero para poder guardar el documento.
+        </div>
+    <?php elseif (isset($_GET['error'])): ?>
         <div style="padding: 15px; background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; border-radius: 5px; margin-bottom: 20px;">
             <strong>Error al guardar el documento:</strong><br>
             <?= htmlspecialchars(urldecode($_GET['error'])) ?>

--- a/src/pages/tipos_cambio_form.php
+++ b/src/pages/tipos_cambio_form.php
@@ -44,10 +44,7 @@ if (isset($_GET['id'])) {
 
         <div class="form-group">
             <label for="fecha">Fecha</label>
-            <div style="display: flex; align-items: center;">
-                <input type="date" id="fecha" name="fecha" value="<?= htmlspecialchars($item['fecha'] ?? date('Y-m-d')) ?>" required style="flex-grow: 1;">
-                <button type="button" id="btn-sunat-tc" class="btn-submit" style="margin-left: 10px; flex-shrink: 0;">SUNAT</button>
-            </div>
+            <input type="date" id="fecha" name="fecha" value="<?= htmlspecialchars($item['fecha'] ?? date('Y-m-d')) ?>" required>
         </div>
         <div class="form-group">
             <label for="compra">Tipo de Cambio (Compra)</label>
@@ -61,50 +58,3 @@ if (isset($_GET['id'])) {
         <button type="submit" class="btn-submit"><?= $is_edit ? 'Actualizar' : 'Crear' ?> Registro</button>
     </form>
 </section>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const btnSunat = document.getElementById('btn-sunat-tc');
-    const fechaInput = document.getElementById('fecha');
-    const compraInput = document.getElementById('compra');
-    const ventaInput = document.getElementById('venta');
-
-    btnSunat.addEventListener('click', async function() {
-        const fecha = fechaInput.value;
-        if (!fecha) {
-            alert('Por favor, seleccione una fecha.');
-            return;
-        }
-
-        this.disabled = true;
-        this.textContent = '...';
-
-        try {
-            const response = await fetch(`../src/ajax/get_tipo_cambio.php?fecha=${fecha}`);
-            if (!response.ok) {
-                const errorData = await response.json().catch(() => ({ error: 'Error de red o respuesta no válida.' }));
-                throw new Error(errorData.error || `Error: ${response.statusText}`);
-            }
-
-            const data = await response.json();
-            if (data.error) {
-                throw new Error(data.error);
-            }
-
-            if (data.compra && data.venta) {
-                compraInput.value = data.compra.toFixed(4);
-                ventaInput.value = data.venta.toFixed(4);
-            } else {
-                alert('La respuesta de la API no contiene los datos de compra y venta esperados.');
-            }
-
-        } catch (error) {
-            console.error('Error al consultar tipo de cambio:', error);
-            alert(`Error al consultar tipo de cambio: ${error.message}`);
-        } finally {
-            this.disabled = false;
-            this.textContent = 'SUNAT';
-        }
-    });
-});
-</script>


### PR DESCRIPTION
This commit changes the source of the exchange rate on the 'Ingreso de Documentos' form from an external API to the local `tipos_cambio` table.

- A new stored procedure `sp_read_tipo_cambio_by_fecha` is added to fetch the exchange rate by date.
- The `get_tipo_cambio.php` AJAX endpoint is refactored to use this new stored procedure.
- If no exchange rate is found for a given date, it now defaults to 0.00.
- Server-side validation is added to `documentos_process.php` to ensure the exchange rate is greater than zero before saving a document.
- A corresponding error message is added to the form to inform the user of this requirement.