### PR TITLE
feat: Restore SUNAT button and refactor TC source

### DIFF
--- a/src/pages/tipos_cambio_form.php
+++ b/src/pages/tipos_cambio_form.php
@@ -44,7 +44,10 @@ if (isset($_GET['id'])) {
 
         <div class="form-group">
             <label for="fecha">Fecha</label>
-            <input type="date" id="fecha" name="fecha" value="<?= htmlspecialchars($item['fecha'] ?? date('Y-m-d')) ?>" required>
+            <div style="display: flex; align-items: center;">
+                <input type="date" id="fecha" name="fecha" value="<?= htmlspecialchars($item['fecha'] ?? date('Y-m-d')) ?>" required style="flex-grow: 1;">
+                <button type="button" id="btn-sunat-tc" class="btn-submit" style="margin-left: 10px; flex-shrink: 0;">SUNAT</button>
+            </div>
         </div>
         <div class="form-group">
             <label for="compra">Tipo de Cambio (Compra)</label>
@@ -58,3 +61,55 @@ if (isset($_GET['id'])) {
         <button type="submit" class="btn-submit"><?= $is_edit ? 'Actualizar' : 'Crear' ?> Registro</button>
     </form>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btnSunat = document.getElementById('btn-sunat-tc');
+    const fechaInput = document.getElementById('fecha');
+    const compraInput = document.getElementById('compra');
+    const ventaInput = document.getElementById('venta');
+
+    btnSunat.addEventListener('click', async function() {
+        const fecha = fechaInput.value;
+        if (!fecha) {
+            alert('Por favor, seleccione una fecha.');
+            return;
+        }
+
+        this.disabled = true;
+        this.textContent = '...';
+
+        try {
+            // Este endpoint ahora consulta la DB local, pero la funcionalidad del botón es la misma.
+            const response = await fetch(`../src/ajax/get_tipo_cambio.php?fecha=${fecha}`);
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ error: 'Error de red o respuesta no válida.' }));
+                throw new Error(errorData.error || `Error: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            if (data.error) {
+                throw new Error(data.error);
+            }
+
+            if (data.compra !== undefined && data.venta !== undefined) {
+                 // Si el origen es NO_ENCONTRADO, alerta al usuario pero igual rellena con 0.00
+                if (data.origen === 'NO_ENCONTRADO') {
+                    alert('No se encontró un tipo de cambio para la fecha seleccionada en la base de datos local. Se usarán los valores 0.00.');
+                }
+                compraInput.value = parseFloat(data.compra).toFixed(4);
+                ventaInput.value = parseFloat(data.venta).toFixed(4);
+            } else {
+                alert('La respuesta de la API no contiene los datos de compra y venta esperados.');
+            }
+
+        } catch (error) {
+            console.error('Error al consultar tipo de cambio:', error);
+            alert(`Error al consultar tipo de cambio: ${error.message}`);
+        } finally {
+            this.disabled = false;
+            this.textContent = 'SUNAT';
+        }
+    });
+});
+</script>


### PR DESCRIPTION
This commit addresses two user requests:
1.  It restores the 'SUNAT' button functionality to the 'tipos_cambio_form.php' page, which was accidentally removed in a previous cleanup.
2.  It refactors the `get_tipo_cambio.php` AJAX endpoint to source data from the local `tipos_cambio` database table instead of an external API.
3.  It adds server-side validation to the document creation process to ensure the exchange rate is greater than zero.