### PR TITLE
fix: Correctly handle zero value for exchange rate

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -474,12 +474,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             }
             const data = await response.json();
-            if (data && data.venta) {
-                tipoCambioInput.value = data.venta.toFixed(4);
+            if (data && data.venta !== undefined) {
+                tipoCambioInput.value = parseFloat(data.venta).toFixed(4);
                 // Disparar el evento input para que se recalculen los totales
                 tipoCambioInput.dispatchEvent(new Event('input', { bubbles: true }));
             } else {
                 console.log('La respuesta de la API no contiene el valor de venta esperado.');
+                tipoCambioInput.value = (0.0).toFixed(4); // Poner 0.0000 si no hay valor
+                tipoCambioInput.dispatchEvent(new Event('input', { bubbles: true }));
             }
         } catch (error) {
             console.error('Error al obtener el tipo de cambio:', error);


### PR DESCRIPTION
This commit fixes a JavaScript bug on the 'Ingreso de Documentos' form.

- The `fetchAndSetTipoCambio` function has been modified to correctly handle a `0.00` value returned from the AJAX call.
- Previously, a `0.00` value was treated as falsy, and the input field was not updated.
- The condition now explicitly checks if `data.venta` is defined, ensuring that the input field is correctly set to '0.0000' when no exchange rate is found in the local database.