### PR TITLE
feat: Implement reusable modal and AJAX form submission

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -90,3 +90,38 @@ body {
     font-size: 28px;
     color: #004a99;
 }
+
+/* Estilos para el Modal Reutilizable */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background-color: #fff;
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    text-align: center;
+    max-width: 400px;
+    width: 90%;
+}
+
+.modal-content p {
+    margin-bottom: 20px;
+    font-size: 16px;
+    color: #333;
+}
+
+.modal-content button {
+    background-color: #005cb3;
+    min-width: 100px;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const modal = document.getElementById('reusableModal');
+    const modalMessage = document.getElementById('modalMessage');
+    const modalOkButton = document.getElementById('modalOkButton');
+
+    // Función global para mostrar el modal
+    window.showAlertModal = function(message) {
+        if (modal && modalMessage) {
+            modalMessage.textContent = message;
+            modal.style.display = 'flex';
+        }
+    }
+
+    // Evento para cerrar el modal
+    if (modalOkButton && modal) {
+        modalOkButton.addEventListener('click', function() {
+            modal.style.display = 'none';
+        });
+    }
+
+    // Opcional: cerrar el modal si se hace clic fuera de él
+    if (modal) {
+        modal.addEventListener('click', function(event) {
+            if (event.target === modal) {
+                modal.style.display = 'none';
+            }
+        });
+    }
+});

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -2,123 +2,96 @@
 session_start();
 require_once __DIR__ . '/../database.php';
 
-if (!isset($_SESSION['user_id'])) {
-    header('Location: ../../public/login.php');
+// --- Helper para enviar respuesta JSON y salir ---
+function send_json_response($data) {
+    header('Content-Type: application/json');
+    echo json_encode($data);
     exit();
 }
 
+if (!isset($_SESSION['user_id'])) {
+    send_json_response(['status' => 'error', 'message' => 'Acceso no autorizado. Sesión no iniciada.']);
+}
+
+$is_ajax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest';
 $action = $_REQUEST['action'] ?? null;
 $pdo = getDbConnection();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Validación de Tipo de Cambio
+    // --- Validación de datos ---
     $tipo_cambio_val = isset($_POST['tipo_cambio']) ? (float)$_POST['tipo_cambio'] : 0;
     if ($tipo_cambio_val <= 0) {
-        $id_documento = $_POST['id_documento'] ?? null;
-        $redirect_url = '../../public/index.php?page=ingreso_documentos_form&error=tipo_cambio_zero';
-        if (!empty($id_documento)) {
-            $redirect_url .= '&id=' . $id_documento;
-        }
-        header('Location: ' . $redirect_url);
-        exit();
+        send_json_response(['status' => 'error', 'message' => 'El tipo de cambio debe ser mayor a cero para poder guardar el documento.']);
     }
 
-    // Lógica para CREATE y UPDATE
     // --- Obtener datos del formulario ---
     $id_tipo_documento = $_POST['id_tipo_documento'];
-$fecha_emision = $_POST['fecha_emision'];
-$serie_documento = $_POST['serie_documento'];
-$numero_documento = $_POST['numero_documento'];
-$id_auxiliar = $_POST['id_auxiliar'];
-$moneda_principal = $_POST['moneda'];
-$tipo_cambio = (float)($_POST['tipo_cambio'] ?? 1.0);
-$id_proyecto = $_POST['id_proyecto'];
-$id_centro_costo = $_POST['id_centro_costo'];
-$id_sub_proyecto = $_POST['id_sub_proyecto'] ?? null;
-$glosa = $_POST['glosa'];
-$id_usuario_registro = $_SESSION['user_id'];
-$detalle_items = $_POST['detalle'] ?? [];
+    $fecha_emision = $_POST['fecha_emision'];
+    $serie_documento = $_POST['serie_documento'];
+    $numero_documento = $_POST['numero_documento'];
+    $id_auxiliar = $_POST['id_auxiliar'];
+    $moneda_principal = $_POST['moneda'];
+    $tipo_cambio = (float)($_POST['tipo_cambio'] ?? 1.0);
+    $id_proyecto = $_POST['id_proyecto'];
+    $id_centro_costo = $_POST['id_centro_costo'];
+    $id_sub_proyecto = $_POST['id_sub_proyecto'] ?? null;
+    $glosa = $_POST['glosa'];
+    $id_usuario_registro = $_SESSION['user_id'];
+    $detalle_items = $_POST['detalle'] ?? [];
 
-// --- Recalcular todo en el backend para seguridad ---
-$subtotal_principal = 0;
-$total_soles_acumulado = 0;
-$total_dolares_acumulado = 0;
-
-foreach ($detalle_items as &$item) {
-    $cantidad = (float)($item['cantidad'] ?? 0);
-    $precio_unitario = (float)($item['precio_unitario'] ?? 0);
-    $precio_total_item = $cantidad * $precio_unitario;
-
-    $item['precio_total'] = $precio_total_item;
-
-    if ($moneda_principal === 'SOLES') {
-        $item['total_soles'] = $precio_total_item;
-        $item['total_dolares'] = $tipo_cambio > 0 ? $precio_total_item / $tipo_cambio : 0;
-    } else { // DOLARES
-        $item['total_dolares'] = $precio_total_item;
-        $item['total_soles'] = $precio_total_item * $tipo_cambio;
-    }
-
-    $subtotal_principal += $item['precio_total'];
-    $total_soles_acumulado += $item['total_soles'];
-    $total_dolares_acumulado += $item['total_dolares'];
-}
-unset($item); // Romper la referencia del bucle
-
-$igv_principal = $subtotal_principal * 0.18;
-$total_principal = $subtotal_principal + $igv_principal;
-
-// --- Lógica de guardado con Transacción ---
-$is_update = isset($_POST['id_documento']) && !empty($_POST['id_documento']);
-
-try {
-    $pdo->beginTransaction();
-
-    if ($is_update) {
-        // --- LÓGICA DE ACTUALIZACIÓN ---
-        $id_documento = $_POST['id_documento'];
-
-        // 1. Actualizar la cabecera
-        $stmt_header = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-        $stmt_header->execute([
-            $id_documento, $id_tipo_documento, $id_proyecto, $id_sub_proyecto, $id_centro_costo, $id_auxiliar,
-            $serie_documento, $numero_documento, $fecha_emision, $moneda_principal, $tipo_cambio,
-            $subtotal_principal, $igv_principal, $total_principal,
-            $total_soles_acumulado + ($total_soles_acumulado * 0.18),
-            $total_dolares_acumulado + ($total_dolares_acumulado * 0.18),
-            $glosa
-        ]);
-
-        // 2. Borrar detalle antiguo
-        $stmt_delete_detalle = $pdo->prepare("CALL sp_delete_documento_detalle_by_id_documento(?)");
-        $stmt_delete_detalle->execute([$id_documento]);
-
-        // 3. Insertar nuevo detalle
-        $stmt_detalle = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?)");
-        foreach ($detalle_items as $index => $item) {
-            $stmt_detalle->execute([
-                $id_documento, $index + 1, $item['cantidad'], $item['descripcion'], $item['id_concepto'],
-                $item['precio_unitario'], $item['precio_total'], $item['total_soles'], $item['total_dolares']
-            ]);
+    // --- Recalcular todo en el backend para seguridad ---
+    $subtotal_principal = 0;
+    foreach ($detalle_items as &$item) {
+        $cantidad = (float)($item['cantidad'] ?? 0);
+        $precio_unitario = (float)($item['precio_unitario'] ?? 0);
+        $item['precio_total'] = $cantidad * $precio_unitario;
+        if ($moneda_principal === 'SOLES') {
+            $item['total_soles'] = $item['precio_total'];
+            $item['total_dolares'] = $tipo_cambio > 0 ? $item['precio_total'] / $tipo_cambio : 0;
+        } else {
+            $item['total_dolares'] = $item['precio_total'];
+            $item['total_soles'] = $item['precio_total'] * $tipo_cambio;
         }
+        $subtotal_principal += $item['precio_total'];
+    }
+    unset($item);
+    $igv_principal = $subtotal_principal * 0.18;
+    $total_principal = $subtotal_principal + $igv_principal;
+    $total_soles_acumulado = array_sum(array_column($detalle_items, 'total_soles'));
+    $total_dolares_acumulado = array_sum(array_column($detalle_items, 'total_dolares'));
 
-    } else {
-        // --- LÓGICA DE CREACIÓN (EXISTENTE) ---
-        $stmt_header = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
-        $stmt_header->execute([
-            $id_tipo_documento, $id_proyecto, $id_sub_proyecto, $id_centro_costo, $id_auxiliar, $id_usuario_registro,
-            $serie_documento, $numero_documento, $fecha_emision, $moneda_principal, $tipo_cambio,
-            $subtotal_principal, $igv_principal, $total_principal,
-            $total_soles_acumulado + ($total_soles_acumulado * 0.18),
-            $total_dolares_acumulado + ($total_dolares_acumulado * 0.18),
-            $glosa
-        ]);
-        $stmt_header->closeCursor();
-        $result = $pdo->query("SELECT @new_id AS new_id")->fetch(PDO::FETCH_ASSOC);
-        $id_documento = $result['new_id'];
+    // --- Lógica de guardado con Transacción ---
+    $is_update = isset($_POST['id_documento']) && !empty($_POST['id_documento']);
 
-        if (!$id_documento) {
-            throw new Exception("No se pudo obtener el ID del nuevo documento.");
+    try {
+        $pdo->beginTransaction();
+        if ($is_update) {
+            $id_documento = $_POST['id_documento'];
+            $stmt_header = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt_header->execute([
+                $id_documento, $id_tipo_documento, $id_proyecto, $id_sub_proyecto, $id_centro_costo, $id_auxiliar,
+                $serie_documento, $numero_documento, $fecha_emision, $moneda_principal, $tipo_cambio,
+                $subtotal_principal, $igv_principal, $total_principal,
+                $total_soles_acumulado + ($total_soles_acumulado * 0.18),
+                $total_dolares_acumulado + ($total_dolares_acumulado * 0.18),
+                $glosa
+            ]);
+            $stmt_delete_detalle = $pdo->prepare("CALL sp_delete_documento_detalle_by_id_documento(?)");
+            $stmt_delete_detalle->execute([$id_documento]);
+        } else {
+            $stmt_header = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
+            $stmt_header->execute([
+                $id_tipo_documento, $id_proyecto, $id_sub_proyecto, $id_centro_costo, $id_auxiliar, $id_usuario_registro,
+                $serie_documento, $numero_documento, $fecha_emision, $moneda_principal, $tipo_cambio,
+                $subtotal_principal, $igv_principal, $total_principal,
+                $total_soles_acumulado + ($total_soles_acumulado * 0.18),
+                $total_dolares_acumulado + ($total_dolares_acumulado * 0.18),
+                $glosa
+            ]);
+            $stmt_header->closeCursor();
+            $result = $pdo->query("SELECT @new_id AS new_id")->fetch(PDO::FETCH_ASSOC);
+            $id_documento = $result['new_id'];
+            if (!$id_documento) throw new Exception("No se pudo obtener el ID del nuevo documento.");
         }
 
         $stmt_detalle = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?)");
@@ -128,29 +101,23 @@ try {
                 $item['precio_unitario'], $item['precio_total'], $item['total_soles'], $item['total_dolares']
             ]);
         }
+
+        $pdo->commit();
+        send_json_response(['status' => 'success', 'message' => 'Documento guardado con éxito.']);
+
+    } catch (Exception $e) {
+        if ($pdo->inTransaction()) $pdo->rollBack();
+        send_json_response(['status' => 'error', 'message' => "Error al guardar: " . $e->getMessage()]);
     }
 
-    $pdo->commit();
-    $success_code = $is_update ? 2 : 1;
-    header('Location: ../../public/index.php?page=ingreso_documentos&success=' . $success_code);
-    exit();
-
-} catch (Exception $e) {
-    if ($pdo->inTransaction()) {
-        $pdo->rollBack();
-    }
-    $error_message = urlencode("Error al guardar: " . $e->getMessage());
-    header('Location: ../../public/index.php?page=ingreso_documentos_form&error=' . $error_message);
-    exit();
-}
 } elseif ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'delete') {
-    // Lógica para DELETE
+    // La lógica de DELETE sigue siendo por redirección por simplicidad.
     $id_documento = $_GET['id'] ?? null;
     if ($id_documento) {
         try {
             $stmt = $pdo->prepare("CALL sp_delete_documento(?)");
             $stmt->execute([$id_documento]);
-            header('Location: ../../public/index.php?page=ingreso_documentos&success=3'); // 3 = deleted
+            header('Location: ../../public/index.php?page=ingreso_documentos&success=3');
         } catch (Exception $e) {
             header('Location: ../../public/index.php?page=ingreso_documentos&error=' . urlencode($e->getMessage()));
         }

--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -30,5 +30,15 @@
         });
     });
     </script>
+
+    <!-- Reusable Modal -->
+    <div id="reusableModal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <p id="modalMessage"></p>
+            <button id="modalOkButton" class="btn">Aceptar</button>
+        </div>
+    </div>
+
+    <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -601,5 +601,54 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+
+    // --- Lógica de Envío con AJAX ---
+    const mainForm = document.querySelector('form[action="../src/actions/documentos_process.php"]');
+    mainForm.addEventListener('submit', async function(event) {
+        event.preventDefault(); // Detener el envío tradicional
+
+        const saveButton = this.querySelector('.btn-save');
+        saveButton.disabled = true;
+        saveButton.textContent = 'Guardando...';
+
+        const formData = new FormData(this);
+
+        // Añadir totales calculados al FormData
+        formData.append('subtotal_display', document.getElementById('subtotal').textContent);
+        formData.append('igv_display', document.getElementById('igv').textContent);
+        formData.append('total_display', document.getElementById('total').textContent);
+
+        try {
+            const response = await fetch(this.action, {
+                method: 'POST',
+                body: formData
+            });
+
+            if (!response.ok) {
+                throw new Error(`Error de red: ${response.statusText}`);
+            }
+
+            const result = await response.json();
+
+            if (result.status === 'success') {
+                // Usar showAlertModal para el éxito también
+                showAlertModal(result.message);
+                // Redirigir después de que el usuario cierre el modal
+                document.getElementById('modalOkButton').onclick = function() {
+                    window.location.href = 'index.php?page=ingreso_documentos';
+                };
+            } else {
+                // Usar el modal para el error
+                showAlertModal(result.message || 'Ocurrió un error desconocido.');
+            }
+
+        } catch (error) {
+            console.error('Error en el envío del formulario:', error);
+            showAlertModal(`Error en el envío del formulario: ${error.message}`);
+        } finally {
+            saveButton.disabled = false;
+            saveButton.textContent = 'Guardar Documento';
+        }
+    });
 });
 </script>


### PR DESCRIPTION
This commit refactors the document submission process to use AJAX and introduces a reusable modal for user alerts.

- A reusable modal component has been added to the footer and styled in the main CSS file.
- A new `main.js` file contains a global function `showAlertModal()` to display messages.
- The `documentos_process.php` script has been refactored to handle AJAX requests and return JSON responses instead of redirecting on validation errors.
- The `ingreso_documentos_form.php` now uses AJAX for form submission, preventing page reloads and data loss when a validation error occurs.
- Validation errors are now displayed in the new modal.