### PR TITLE
feat: Add duplicate validation and fix various form issues

### DIFF
--- a/src/pages/sub_proyectos_form.php
+++ b/src/pages/sub_proyectos_form.php
@@ -22,9 +22,14 @@ try {
         $is_edit = true;
         $item_id = $_GET['id'];
 
+        // Re-establish connection to prevent "MySQL server has gone away"
+        $pdo = null;
+        $pdo = getDbConnection();
+
         $stmt_item = $pdo->prepare("CALL sp_read_sub_proyecto_by_id(?)");
         $stmt_item->execute([$item_id]);
         $item = $stmt_item->fetch();
+        $stmt_item->closeCursor();
     }
 } catch (PDOException $e) {
     die("Error al obtener datos: " . $e->getMessage());


### PR DESCRIPTION
This commit implements several new features, layout changes, and bug fixes for the document and sub-project forms.

- Adds server-side validation to prevent the creation of duplicate documents.
- Disables key fields (type, series, number, auxiliar) when editing an existing document.
- Adjusts the layout of the document form for better readability.
- Implements a reusable modal for alerts and refactors the document form submission to use AJAX, preventing data loss on validation errors.
- Fixes a 'MySQL server has gone away' bug in the sub-project edit form by re-establishing the database connection.