### PR TITLE
fix: Correct DB connection and session errors on Auxiliares page

### DIFF
--- a/src/pages/auxiliares.php
+++ b/src/pages/auxiliares.php
@@ -22,13 +22,20 @@ try {
     $stmt = $pdo->prepare("CALL sp_read_all_auxiliares(?, ?, ?)");
     $stmt->execute([$filter_nombre, $filter_num_doc, $filter_tipo_aux]);
     $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    $stmt->closeCursor(); // This is critical to allow the next query to run.
+
+    // THE CRITICAL FIX:
+    // Some drivers/environments require explicitly clearing all potential subsequent rowsets
+    // from a stored procedure call before another query can be made on the same connection.
+    // The do-while loop with nextRowset() is the most robust way to do this.
+    while ($stmt->nextRowset());
+
+    $stmt->closeCursor();
 
     // Second query: get the types for the filter dropdown
     $stmt_tipos = $pdo->prepare("SELECT id, nombre FROM tipos_auxiliar WHERE estado = 1 ORDER BY nombre");
     $stmt_tipos->execute();
     $tipos_auxiliar = $stmt_tipos->fetchAll(PDO::FETCH_ASSOC);
-    $stmt_tipos->closeCursor(); // Good practice to close all cursors.
+    $stmt_tipos->closeCursor();
 
 } catch (PDOException $e) {
     // Provide a user-friendly error message


### PR DESCRIPTION
Fixes a 'MySQL server has gone away' (SQLSTATE[HY000]: General error: 2006) error that occurred on the `auxiliares.php` page. The error was caused by not closing all database cursors after executing queries, which left the PDO connection in an unstable state. This is resolved by using a `nextRowset()` loop to exhaust all potential result sets from stored procedure calls.

This commit also removes a redundant `session_start()` call that was generating a PHP notice.