### PR TITLE
fix(auxiliares): Correct session bug and apply consistent style to form

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../database.php';
-session_start(); // Required to access session variables
 
+// session_start() is removed.
 if (!isset($_SESSION['user_id'])) {
     header('Location: ../../public/login.php?error=Acceso no autorizado');
     exit();
@@ -19,106 +19,113 @@ if (isset($_GET['id'])) {
     $item = $stmt->fetch(PDO::FETCH_ASSOC);
     $stmt->closeCursor();
 }
+
+// Pre-fetch data for dropdowns
+$tipos_auxiliar = $pdo->query("SELECT id, nombre FROM tipos_auxiliar WHERE estado = 1 ORDER BY nombre")->fetchAll(PDO::FETCH_ASSOC);
+$tipos_doc_identidad = $pdo->query("CALL sp_read_tipos_documento_identidad_for_dropdown()")->fetchAll(PDO::FETCH_ASSOC);
+
 ?>
 
-<div class="container mt-4">
-    <div class="card">
-        <div class="card-header">
-            <h4 class="mb-0"><?= $is_edit ? 'Editar' : 'Nuevo'; ?> Auxiliar</h4>
+<style>
+    .form-container { max-width: 800px; }
+    .form-group { margin-bottom: 15px; }
+    .form-group label { display: block; margin-bottom: 5px; font-weight: bold; }
+    .form-group input, .form-group select, .form-group textarea { width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+    .form-row { display: flex; gap: 20px; }
+    .form-row .form-group { flex: 1; }
+    .btn-submit { background-color: #005cb3; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
+    .btn-cancel { background-color: #6c757d; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; }
+    .form-actions { text-align: right; margin-top: 20px; }
+    .alert { padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px; }
+    .alert-danger { color: #721c24; background-color: #f8d7da; border-color: #f5c6cb; }
+</style>
+
+<header>
+    <h1><?= $is_edit ? 'Editar' : 'Nuevo'; ?> Auxiliar</h1>
+</header>
+
+<section class="form-container">
+    <?php if (isset($_GET['error'])): ?>
+        <div class="alert alert-danger">
+            <?= htmlspecialchars($_GET['error']) ?>
         </div>
-        <div class="card-body">
-            <?php if (isset($_GET['error'])): ?>
-                <div class="alert alert-danger" role="alert">
-                    <?= htmlspecialchars($_GET['error']) ?>
-                </div>
-            <?php endif; ?>
-            <form id="auxiliarForm" action="../src/actions/auxiliares_process.php" method="post">
-                <input type="hidden" name="action" value="<?= $is_edit ? 'update' : 'create' ?>">
-                <?php if ($is_edit): ?>
-                    <input type="hidden" name="id" value="<?= htmlspecialchars($item['id']) ?>">
-                <?php endif; ?>
+    <?php endif; ?>
 
-                <div class="mb-3">
-                    <label for="razon_social_nombres" class="form-label">Razón Social o Nombres Completos</label>
-                    <input type="text" class="form-control" id="razon_social_nombres" name="razon_social_nombres" value="<?= htmlspecialchars($item['razon_social_nombres'] ?? '') ?>" required>
-                </div>
+    <form id="auxiliarForm" action="../src/actions/auxiliares_process.php" method="post">
+        <input type="hidden" name="action" value="<?= $is_edit ? 'update' : 'create' ?>">
+        <?php if ($is_edit): ?>
+            <input type="hidden" name="id" value="<?= htmlspecialchars($item['id']) ?>">
+        <?php endif; ?>
 
-                <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <label for="id_tipo_auxiliar" class="form-label">Tipo de Auxiliar</label>
-                        <select class="form-select" id="id_tipo_auxiliar" name="id_tipo_auxiliar" required>
-                            <option value="">Seleccione un tipo</option>
-                            <?php
-                            $stmt_tipos = $pdo->query("SELECT id, nombre FROM tipos_auxiliar WHERE estado = 1 ORDER BY nombre");
-                            while ($row = $stmt_tipos->fetch(PDO::FETCH_ASSOC)) {
-                                $selected = (isset($item['id_tipo_auxiliar']) && $row['id'] == $item['id_tipo_auxiliar']) ? 'selected' : '';
-                                echo "<option value='{$row['id']}' {$selected}>{$row['nombre']}</option>";
-                            }
-                            ?>
-                        </select>
-                    </div>
-                    <div class="col-md-6 mb-3">
-                        <label for="id_tipo_documento_identidad" class="form-label">Tipo Documento Identidad</label>
-                        <select class="form-select" id="id_tipo_documento_identidad" name="id_tipo_documento_identidad" required>
-                            <option value="">Seleccione un tipo</option>
-                            <?php
-                            $stmt_docs = $pdo->prepare("CALL sp_read_tipos_documento_identidad_for_dropdown()");
-                            $stmt_docs->execute();
-                            while ($row = $stmt_docs->fetch(PDO::FETCH_ASSOC)) {
-                                $selected = (isset($item['id_tipo_documento_identidad']) && $row['id'] == $item['id_tipo_documento_identidad']) ? 'selected' : '';
-                                echo "<option value='{$row['id']}' {$selected}>{$row['nombre']}</option>";
-                            }
-                            $stmt_docs->closeCursor();
-                            ?>
-                        </select>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <label for="num_doc_identidad" class="form-label">Nro. Documento</label>
-                        <input type="text" class="form-control" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($item['num_doc_identidad'] ?? '') ?>" required>
-                    </div>
-                    <div class="col-md-6 mb-3">
-                         <label for="ubigeo" class="form-label">Ubigeo</label>
-                        <input type="text" class="form-control" id="ubigeo" name="ubigeo" value="<?= htmlspecialchars($item['ubigeo'] ?? '') ?>">
-                    </div>
-                </div>
-
-                <div class="mb-3">
-                    <label for="direccion" class="form-label">Dirección</label>
-                    <input type="text" class="form-control" id="direccion" name="direccion" value="<?= htmlspecialchars($item['direccion'] ?? '') ?>">
-                </div>
-
-                 <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <label for="telefono" class="form-label">Teléfono</label>
-                        <input type="text" class="form-control" id="telefono" name="telefono" value="<?= htmlspecialchars($item['telefono'] ?? '') ?>">
-                    </div>
-                    <div class="col-md-6 mb-3">
-                        <label for="email" class="form-label">Email</label>
-                        <input type="email" class="form-control" id="email" name="email" value="<?= htmlspecialchars($item['email'] ?? '') ?>">
-                    </div>
-                </div>
-
-                <?php if ($is_edit): ?>
-                <div class="mb-3">
-                    <label for="estado" class="form-label">Estado</label>
-                    <select class="form-select" id="estado" name="estado" required>
-                        <option value="1" <?= (isset($item['estado']) && $item['estado'] == 1) ? 'selected' : '' ?>>Activo</option>
-                        <option value="0" <?= (isset($item['estado']) && $item['estado'] == 0) ? 'selected' : '' ?>>Inactivo</option>
-                    </select>
-                </div>
-                <?php endif; ?>
-
-                <div class="d-flex justify-content-end">
-                     <a href="index.php?page=auxiliares" class="btn btn-secondary me-2">Cancelar</a>
-                    <button type="submit" class="btn btn-primary">Guardar</button>
-                </div>
-            </form>
+        <div class="form-group">
+            <label for="razon_social_nombres">Razón Social o Nombres Completos</label>
+            <input type="text" id="razon_social_nombres" name="razon_social_nombres" value="<?= htmlspecialchars($item['razon_social_nombres'] ?? '') ?>" required>
         </div>
-    </div>
-</div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="id_tipo_auxiliar">Tipo de Auxiliar</label>
+                <select id="id_tipo_auxiliar" name="id_tipo_auxiliar" required>
+                    <option value="">Seleccione un tipo</option>
+                    <?php foreach ($tipos_auxiliar as $tipo): ?>
+                        <option value="<?= $tipo['id'] ?>" <?= (isset($item['id_tipo_auxiliar']) && $row['id'] == $item['id_tipo_auxiliar']) ? 'selected' : '' ?>><?= htmlspecialchars($tipo['nombre']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="id_tipo_documento_identidad">Tipo Documento Identidad</label>
+                <select id="id_tipo_documento_identidad" name="id_tipo_documento_identidad" required>
+                    <option value="">Seleccione un tipo</option>
+                     <?php foreach ($tipos_doc_identidad as $doc): ?>
+                        <option value="<?= $doc['id'] ?>" <?= (isset($item['id_tipo_documento_identidad']) && $doc['id'] == $item['id_tipo_documento_identidad']) ? 'selected' : '' ?>><?= htmlspecialchars($doc['nombre']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="num_doc_identidad">Nro. Documento</label>
+                <input type="text" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($item['num_doc_identidad'] ?? '') ?>" required>
+            </div>
+            <div class="form-group">
+                 <label for="ubigeo">Ubigeo</label>
+                <input type="text" id="ubigeo" name="ubigeo" value="<?= htmlspecialchars($item['ubigeo'] ?? '') ?>">
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="direccion">Dirección</label>
+            <input type="text" id="direccion" name="direccion" value="<?= htmlspecialchars($item['direccion'] ?? '') ?>">
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="telefono">Teléfono</label>
+                <input type="text" id="telefono" name="telefono" value="<?= htmlspecialchars($item['telefono'] ?? '') ?>">
+            </div>
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" value="<?= htmlspecialchars($item['email'] ?? '') ?>">
+            </div>
+        </div>
+
+        <?php if ($is_edit): ?>
+        <div class="form-group">
+            <label for="estado">Estado</label>
+            <select id="estado" name="estado" required>
+                <option value="1" <?= (isset($item['estado']) && $item['estado'] == 1) ? 'selected' : '' ?>>Activo</option>
+                <option value="0" <?= (isset($item['estado']) && $item['estado'] == 0) ? 'selected' : '' ?>>Inactivo</option>
+            </select>
+        </div>
+        <?php endif; ?>
+
+        <div class="form-actions">
+             <a href="index.php?page=auxiliares" class="btn-cancel">Cancelar</a>
+            <button type="submit" class="btn-submit">Guardar</button>
+        </div>
+    </form>
+</section>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -134,44 +141,28 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        // We need an AJAX call to get the longitud
-        // Let's create a small endpoint for this.
-        // For now, let's assume we can get it from a data attribute if it exists.
-        // This is a temporary solution until we fix the AJAX part.
-        // The previous code had a major flaw: it couldn't get the length for existing items.
-
-        const selectedOption = tipoDocSelect.options[tipoDocSelect.selectedIndex];
-        // The SP for dropdown doesn't return longitud. We need to call the other SP.
-        // This requires an AJAX call.
-
-        // Let's create a new file for this: get_tipo_doc_longitud.php
         fetch(`../src/ajax/get_tipo_doc_longitud.php?id=${tipoDocId}`)
             .then(response => response.json())
             .then(data => {
+                nroDocInput.disabled = false;
                 if (data.longitud && data.longitud > 0) {
                     nroDocInput.maxLength = data.longitud;
-                    nroDocInput.disabled = false;
                 } else {
                     nroDocInput.removeAttribute('maxlength');
-                    nroDocInput.disabled = false; // Allow any length if not specified
                 }
             })
             .catch(error => {
                 console.error('Error fetching document length:', error);
-                nroDocInput.disabled = false; // Enable anyway on error
+                nroDocInput.disabled = false;
             });
     }
 
     tipoDocSelect.addEventListener('change', function() {
-        nroDocInput.value = ''; // Clear the value when type changes
+        nroDocInput.value = '';
         fetchLongitudAndSetMaxLength();
     });
 
-    // Initial state
-    if (tipoDocSelect.value) {
-        fetchLongitudAndSetMaxLength();
-    } else {
-        nroDocInput.disabled = true;
-    }
+    // Initial state on page load
+    fetchLongitudAndSetMaxLength();
 });
 </script>


### PR DESCRIPTION
This commit addresses two issues on the `auxiliares_form.php` page:

1.  **Bug Fix:** Removes a redundant `session_start()` call that was generating a PHP notice.
2.  **Styling:** Refactors the page's HTML and CSS to align with the self-contained, non-Bootstrap styling used by other maintenance pages in the application. This creates a more consistent user interface.