### PR TITLE
fix(js): Add trim to data attribute to fix SUNAT validation

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -187,7 +187,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     sunatBtn.addEventListener('click', function() {
         const selectedOption = tipoDocSelect.options[tipoDocSelect.selectedIndex];
-        const tipo = selectedOption.getAttribute('data-codigo');
+        const tipo = (selectedOption.getAttribute('data-codigo') || '').trim();
         const numero = nroDocInput.value.trim();
 
         if ((tipo !== 'DNI' && tipo !== 'RUC') || !numero) {


### PR DESCRIPTION
Fixes a bug on the `auxiliares_form.php` page where the SUNAT lookup button would show a validation error even when a valid document type (DNI/RUC) was selected.

The root cause is suspected to be whitespace in the `codigo` data coming from the database. The JavaScript has been made more robust by trimming the `data-codigo` attribute's value before it is checked. This ensures that leading/trailing whitespace does not cause the validation to fail.