### PR TITLE
hotfix(js): Restore SUNAT button functionality on auxiliares form

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -179,6 +179,10 @@ document.addEventListener('DOMContentLoaded', function() {
         // Assuming Bootstrap JS is loaded, as other modals on the site work.
         // Removing the typeof bootstrap check to force usage.
         if (!alertModalInstance) {
+         if (typeof bootstrap === 'undefined') {
+            alert(message); // Fallback if Bootstrap JS is not loaded
+            return;
+        }
             alertModalInstance = new bootstrap.Modal(modalElement);
         }
         document.getElementById('alertModalBody').textContent = message;


### PR DESCRIPTION
This commit reverts a previous change that caused a fatal JavaScript error, preventing the click event on the 'SUNAT' button from firing.

The `if (typeof bootstrap === 'undefined')` check is re-introduced into the `showAlertModal` helper function. This prevents a `ReferenceError` in environments where the Bootstrap JS library may not be loaded when the script runs, ensuring the button remains functional (albeit with a fallback to a native `alert`).