### PR TITLE
fix(sunat): Correct SUNAT lookup logic based on user feedback

### DIFF
--- a/src/ajax/get_sunat_data.php
+++ b/src/ajax/get_sunat_data.php
@@ -1,22 +1,30 @@
 <?php
 header('Content-Type: application/json');
 
-$tipo = $_GET['tipo'] ?? '';
+$tipo_id = $_GET['tipo'] ?? '';
 $numero = $_GET['numero'] ?? '';
 
-if (empty($tipo) || empty($numero)) {
+if (empty($tipo_id) || empty($numero)) {
     http_response_code(400);
     echo json_encode(['error' => 'Tipo y número de documento son requeridos.']);
     exit;
 }
 
-if (!in_array($tipo, ['dni', 'ruc'])) {
+// Map the ID to the API endpoint string, as per user's fix
+$tipo_doc_str = '';
+if ($tipo_id == '1') {
+    $tipo_doc_str = 'dni';
+} elseif ($tipo_id == '6') {
+    $tipo_doc_str = 'ruc';
+}
+
+if (empty($tipo_doc_str)) {
     http_response_code(400);
-    echo json_encode(['error' => 'Tipo de documento no válido. Use "dni" o "ruc".']);
+    echo json_encode(['error' => 'Tipo de documento no válido. Use ID "1" para DNI o "6" para RUC.']);
     exit;
 }
 
-$api_url = "https://api.apis.net.pe/v1/{$tipo}?numero=" . urlencode($numero);
+$api_url = "https://api.apis.net.pe/v1/{$tipo_doc_str}?numero=" . urlencode($numero);
 
 // The user's curl examples don't show an Authorization token.
 // If this API required one, it would be added to the headers like this:

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -229,11 +229,11 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     sunatBtn.addEventListener('click', function() {
-        const selectedOption = tipoDocSelect.options[tipoDocSelect.selectedIndex];
-        const tipo = (selectedOption.getAttribute('data-codigo') || '').trim();
+        const tipo = tipoDocSelect.value; // Use the dropdown's value (the ID)
         const numero = nroDocInput.value.trim();
 
-        if ((tipo !== 'DNI' && tipo !== 'RUC') || !numero) {
+        // Use the IDs for validation, as per user's fix
+        if ((tipo !== '1' && tipo !== '6') || !numero) {
             showAlertModal('Por favor, seleccione un tipo de documento (DNI/RUC) y ingrese un número.');
             return;
         }
@@ -241,7 +241,8 @@ document.addEventListener('DOMContentLoaded', function() {
         sunatBtn.textContent = '...';
         sunatBtn.disabled = true;
 
-        fetch(`../src/ajax/get_sunat_data.php?tipo=${tipo.toLowerCase()}&numero=${numero}`)
+        // Send the ID to the backend proxy
+        fetch(`../src/ajax/get_sunat_data.php?tipo=${tipo}&numero=${numero}`)
             .then(response => {
                 if (!response.ok) {
                     return response.json().then(err => { throw new Error(err.error || `Error HTTP ${response.status}`) });
@@ -253,9 +254,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     throw new Error(data.error);
                 }
 
-                if (tipo === 'DNI') {
+                // Check the ID to determine how to parse the response
+                if (tipo === '1') { // DNI
                     razonSocialInput.value = `${data.nombres} ${data.apellidoPaterno} ${data.apellidoMaterno}`.trim();
-                } else { // RUC
+                } else { // RUC (ID '6')
                     razonSocialInput.value = data.nombre || '';
                     direccionInput.value = `${data.direccion || ''} - ${data.departamento || ''} - ${data.provincia || ''} - ${data.distrito || ''}`;
                     ubigeoInput.value = data.ubigeo || '';


### PR DESCRIPTION
This commit fixes a bug in the SUNAT API lookup feature on the `auxiliares_form.php` page. The previous implementation was using an incorrect value to identify the document type.

Based on the user's provided solution, the logic has been updated in two files:
- `src/pages/auxiliares_form.php`: The JavaScript now sends the document type's database ID (`value` of the dropdown) to the backend proxy.
- `src/ajax/get_sunat_data.php`: The proxy now accepts the ID and maps it to the correct API endpoint string ('dni' or 'ruc').

This makes the feature more robust and functional. Thanks to the user for providing the fix.