### PR TITLE
fix(sunat): Use correct database IDs for SUNAT lookup

### DIFF
--- a/src/ajax/get_sunat_data.php
+++ b/src/ajax/get_sunat_data.php
@@ -10,36 +10,28 @@ if (empty($tipo_id) || empty($numero)) {
     exit;
 }
 
-// Map the ID to the API endpoint string, as per user's fix
+// Map the correct ID to the API endpoint string, as per user's final correction
 $tipo_doc_str = '';
-if ($tipo_id == '1') {
+if ($tipo_id == '3') { // DNI
     $tipo_doc_str = 'dni';
-} elseif ($tipo_id == '6') {
+} elseif ($tipo_id == '4') { // RUC
     $tipo_doc_str = 'ruc';
 }
 
 if (empty($tipo_doc_str)) {
     http_response_code(400);
-    echo json_encode(['error' => 'Tipo de documento no válido. Use ID "1" para DNI o "6" para RUC.']);
+    echo json_encode(['error' => 'Tipo de documento no válido. Use ID "3" para DNI o "4" para RUC.']);
     exit;
 }
 
 $api_url = "https://api.apis.net.pe/v1/{$tipo_doc_str}?numero=" . urlencode($numero);
 
-// The user's curl examples don't show an Authorization token.
-// If this API required one, it would be added to the headers like this:
-// "Authorization: Bearer YOUR_API_TOKEN"
-
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $api_url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HEADER, false);
-// Optional: set a timeout
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-// Optional: for HTTPS, you might need these in some environments
-// curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-// curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 
 $response = curl_exec($ch);
 $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -54,7 +46,6 @@ if ($curl_error) {
 
 if ($http_code !== 200) {
     http_response_code($http_code);
-    // Try to decode the response to see if the API gave a specific error message
     $error_details = json_decode($response, true);
     if (json_last_error() === JSON_ERROR_NONE && isset($error_details['message'])) {
          echo json_encode(['error' => 'Error de la API externa: ' . $error_details['message']]);

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -232,8 +232,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const tipo = tipoDocSelect.value; // Use the dropdown's value (the ID)
         const numero = nroDocInput.value.trim();
 
-        // Use the IDs for validation, as per user's fix
-        if ((tipo !== '1' && tipo !== '6') || !numero) {
+        // Use the correct IDs ('3' and '4'), as per user's final correction
+        if ((tipo !== '3' && tipo !== '4') || !numero) {
             showAlertModal('Por favor, seleccione un tipo de documento (DNI/RUC) y ingrese un número.');
             return;
         }
@@ -254,10 +254,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     throw new Error(data.error);
                 }
 
-                // Check the ID to determine how to parse the response
-                if (tipo === '1') { // DNI
+                // Use correct IDs to parse the response
+                if (tipo === '3') { // DNI
                     razonSocialInput.value = `${data.nombres} ${data.apellidoPaterno} ${data.apellidoMaterno}`.trim();
-                } else { // RUC (ID '6')
+                } else { // RUC (ID '4')
                     razonSocialInput.value = data.nombre || '';
                     direccionInput.value = `${data.direccion || ''} - ${data.departamento || ''} - ${data.provincia || ''} - ${data.distrito || ''}`;
                     ubigeoInput.value = data.ubigeo || '';


### PR DESCRIPTION
This commit applies a user-provided correction to the SUNAT API lookup feature, which was failing due to incorrect hardcoded database IDs for document types.

The logic in `auxiliares_form.php` and `get_sunat_data.php` has been updated to use the correct IDs: '3' for DNI and '4' for RUC.

This resolves the bug and makes the feature functional as intended.