### PR TITLE
feat: Add duplicate assistant validation

### DIFF
--- a/database/final_schema_and_sprocs.sql
+++ b/database/final_schema_and_sprocs.sql
@@ -217,3 +217,20 @@ BEGIN
     DELETE FROM documentos WHERE id = p_id;
 END$$
 DELIMITER ;
+
+-- SPs para Auxiliares
+DROP PROCEDURE IF EXISTS sp_check_auxiliar_duplicado;
+DELIMITER $$
+CREATE PROCEDURE `sp_check_auxiliar_duplicado`(
+    IN p_id_tipo_auxiliar INT,
+    IN p_num_doc_identidad VARCHAR(20),
+    IN p_id INT
+)
+BEGIN
+    SELECT id
+    FROM auxiliares
+    WHERE id_tipo_auxiliar = p_id_tipo_auxiliar
+      AND num_doc_identidad = p_num_doc_identidad
+      AND (p_id IS NULL OR id != p_id);
+END$$
+DELIMITER ;

--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -22,6 +22,17 @@ $redirect_page = '../../public/index.php?page=auxiliares';
 try {
     switch ($action) {
         case 'create':
+            // Check for duplicates
+            $stmt_check = $pdo->prepare("CALL sp_check_auxiliar_duplicado(?, ?, NULL)");
+            $stmt_check->execute([$_POST['id_tipo_auxiliar'], $_POST['num_doc_identidad']]);
+            if ($stmt_check->fetch()) {
+                $stmt_check->closeCursor();
+                $error_message = "Ya existe un auxiliar con el mismo tipo y número de documento.";
+                header('Location: ../../public/index.php?page=auxiliares_form&error_modal=' . urlencode($error_message));
+                exit();
+            }
+            $stmt_check->closeCursor();
+
             $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id_tipo_auxiliar'],
@@ -38,6 +49,18 @@ try {
 
         case 'update':
             if (!isset($_POST['id'])) throw new Exception("ID de auxiliar no proporcionado para actualizar.");
+
+            // Check for duplicates
+            $stmt_check = $pdo->prepare("CALL sp_check_auxiliar_duplicado(?, ?, ?)");
+            $stmt_check->execute([$_POST['id_tipo_auxiliar'], $_POST['num_doc_identidad'], $_POST['id']]);
+            if ($stmt_check->fetch()) {
+                $stmt_check->closeCursor();
+                $error_message = "Ya existe otro auxiliar con el mismo tipo y número de documento.";
+                header('Location: ../../public/index.php?page=auxiliares_form&id=' . $_POST['id'] . '&error_modal=' . urlencode($error_message));
+                exit();
+            }
+            $stmt_check->closeCursor();
+
             $stmt = $pdo->prepare("CALL sp_update_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id'],

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -167,6 +167,13 @@ try {
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    // --- MODAL TRIGGER FROM URL ---
+    const urlParams = new URLSearchParams(window.location.search);
+    const errorModalMessage = urlParams.get('error_modal');
+    if (errorModalMessage) {
+        showAlertModal(errorModalMessage);
+    }
+
     // --- MODAL HELPER ---
     let alertModalInstance;
     function showAlertModal(message) {


### PR DESCRIPTION
Adds a validation to prevent creating assistants with the same type and document number. A new stored procedure is created for the check, and an error is displayed in a modal if a duplicate is found.