### PR TITLE
fix: Ensure Bootstrap JS is loaded for modal

### DIFF
--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -1,6 +1,8 @@
 </main>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         var dropdowns = document.querySelectorAll('.dropdown-toggle');


### PR DESCRIPTION
This fixes a bug where the error modal was not appearing. The Bootstrap JS library was not being loaded, so the JavaScript to trigger the modal was failing. The CDN link for Bootstrap JS has been added to the footer.