### PR TITLE
feat: Retain form data on duplicate validation error

### DIFF
--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -27,6 +27,7 @@ try {
             $stmt_check->execute([$_POST['id_tipo_auxiliar'], $_POST['num_doc_identidad']]);
             if ($stmt_check->fetch()) {
                 $stmt_check->closeCursor();
+                $_SESSION['form_data'] = $_POST;
                 $error_message = "Ya existe un auxiliar con el mismo tipo y número de documento.";
                 header('Location: ../../public/index.php?page=auxiliares_form&error_modal=' . urlencode($error_message));
                 exit();
@@ -55,6 +56,7 @@ try {
             $stmt_check->execute([$_POST['id_tipo_auxiliar'], $_POST['num_doc_identidad'], $_POST['id']]);
             if ($stmt_check->fetch()) {
                 $stmt_check->closeCursor();
+                $_SESSION['form_data'] = $_POST;
                 $error_message = "Ya existe otro auxiliar con el mismo tipo y número de documento.";
                 header('Location: ../../public/index.php?page=auxiliares_form&id=' . $_POST['id'] . '&error_modal=' . urlencode($error_message));
                 exit();

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -10,6 +10,12 @@ $pdo = getDbConnection();
 $item = null;
 $is_edit = false;
 
+// Repopulate form from session data if it exists (e.g., after validation error)
+$form_data = $_SESSION['form_data'] ?? null;
+if ($form_data) {
+    unset($_SESSION['form_data']);
+}
+
 try {
     if (isset($_GET['id'])) {
         $is_edit = true;
@@ -88,8 +94,11 @@ try {
                 <label for="id_tipo_auxiliar">Tipo de Auxiliar</label>
                 <select id="id_tipo_auxiliar" name="id_tipo_auxiliar" required>
                     <option value="">Seleccione un tipo</option>
-                    <?php foreach ($tipos_auxiliar as $tipo): ?>
-                        <option value="<?= $tipo['id'] ?>" <?= (isset($item['id_tipo_auxiliar']) && $tipo['id'] == $item['id_tipo_auxiliar']) ? 'selected' : '' ?>><?= htmlspecialchars($tipo['nombre']) ?></option>
+                    <?php
+                        $selected_tipo_auxiliar = $form_data['id_tipo_auxiliar'] ?? $item['id_tipo_auxiliar'] ?? null;
+                        foreach ($tipos_auxiliar as $tipo):
+                    ?>
+                        <option value="<?= $tipo['id'] ?>" <?= ($tipo['id'] == $selected_tipo_auxiliar) ? 'selected' : '' ?>><?= htmlspecialchars($tipo['nombre']) ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>
@@ -97,8 +106,11 @@ try {
                 <label for="id_tipo_documento_identidad">Tipo Documento Identidad</label>
                 <select id="id_tipo_documento_identidad" name="id_tipo_documento_identidad" required>
                     <option value="" data-codigo="">Seleccione un tipo</option>
-                     <?php foreach ($tipos_doc_identidad as $doc): ?>
-                        <option value="<?= $doc['id'] ?>" data-codigo="<?= htmlspecialchars($doc['codigo']) ?>" <?= (isset($item['id_tipo_documento_identidad']) && $doc['id'] == $item['id_tipo_documento_identidad']) ? 'selected' : '' ?>><?= htmlspecialchars($doc['nombre']) ?></option>
+                     <?php
+                        $selected_tipo_doc = $form_data['id_tipo_documento_identidad'] ?? $item['id_tipo_documento_identidad'] ?? null;
+                        foreach ($tipos_doc_identidad as $doc):
+                     ?>
+                        <option value="<?= $doc['id'] ?>" data-codigo="<?= htmlspecialchars($doc['codigo']) ?>" <?= ($doc['id'] == $selected_tipo_doc) ? 'selected' : '' ?>><?= htmlspecialchars($doc['nombre']) ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>
@@ -107,39 +119,40 @@ try {
             <div class="form-group" style="flex-grow: 2;">
                 <label for="num_doc_identidad">Nro. Documento</label>
                 <div class="input-with-button">
-                    <input type="text" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($item['num_doc_identidad'] ?? '') ?>" required>
+                    <input type="text" id="num_doc_identidad" name="num_doc_identidad" value="<?= htmlspecialchars($form_data['num_doc_identidad'] ?? $item['num_doc_identidad'] ?? '') ?>" required>
                     <button type="button" id="sunatBtn" class="btn btn-sunat">SUNAT</button>
                 </div>
             </div>
             <div class="form-group" style="flex-grow: 1;">
                  <label for="ubigeo">Ubigeo</label>
-                <input type="text" id="ubigeo" name="ubigeo" value="<?= htmlspecialchars($item['ubigeo'] ?? '') ?>">
+                <input type="text" id="ubigeo" name="ubigeo" value="<?= htmlspecialchars($form_data['ubigeo'] ?? $item['ubigeo'] ?? '') ?>">
             </div>
         </div>
         <div class="form-group">
             <label for="razon_social_nombres">Razón Social o Nombres Completos</label>
-            <input type="text" id="razon_social_nombres" name="razon_social_nombres" value="<?= htmlspecialchars($item['razon_social_nombres'] ?? '') ?>" required>
+            <input type="text" id="razon_social_nombres" name="razon_social_nombres" value="<?= htmlspecialchars($form_data['razon_social_nombres'] ?? $item['razon_social_nombres'] ?? '') ?>" required>
         </div>
         <div class="form-group">
             <label for="direccion">Dirección</label>
-            <input type="text" id="direccion" name="direccion" value="<?= htmlspecialchars($item['direccion'] ?? '') ?>">
+            <input type="text" id="direccion" name="direccion" value="<?= htmlspecialchars($form_data['direccion'] ?? $item['direccion'] ?? '') ?>">
         </div>
         <div class="form-row">
             <div class="form-group">
                 <label for="telefono">Teléfono</label>
-                <input type="text" id="telefono" name="telefono" value="<?= htmlspecialchars($item['telefono'] ?? '') ?>">
+                <input type="text" id="telefono" name="telefono" value="<?= htmlspecialchars($form_data['telefono'] ?? $item['telefono'] ?? '') ?>">
             </div>
             <div class="form-group">
                 <label for="email">Email</label>
-                <input type="email" id="email" name="email" value="<?= htmlspecialchars($item['email'] ?? '') ?>">
+                <input type="email" id="email" name="email" value="<?= htmlspecialchars($form_data['email'] ?? $item['email'] ?? '') ?>">
             </div>
         </div>
         <?php if ($is_edit): ?>
         <div class="form-group">
             <label for="estado">Estado</label>
             <select id="estado" name="estado" required>
-                <option value="1" <?= (isset($item['estado']) && $item['estado'] == 1) ? 'selected' : '' ?>>Activo</option>
-                <option value="0" <?= (isset($item['estado']) && $item['estado'] == 0) ? 'selected' : '' ?>>Inactivo</option>
+                <?php $selected_estado = $form_data['estado'] ?? $item['estado'] ?? '1'; ?>
+                <option value="1" <?= ($selected_estado == 1) ? 'selected' : '' ?>>Activo</option>
+                <option value="0" <?= ($selected_estado == 0) ? 'selected' : '' ?>>Inactivo</option>
             </select>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
This enhances the duplicate assistant validation. When a duplicate is detected, the form now retains the user's entered data instead of clearing the fields. This is achieved by storing the form data in the session on validation failure and repopulating the form on reload.