### PR TITLE
fix: Prevent field clearing on duplicate error

### DIFF
--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -217,7 +217,7 @@ window.addEventListener('load', function() {
 
         // Use the correct IDs ('3' and '4'), as per user's final correction
         if ((tipo !== '3' && tipo !== '4') || !numero) {
-            showAlertModal('Por favor, seleccione un tipo de documento (DNI/RUC) y ingrese un número.');
+            window.showAlertModal('Por favor, seleccione un tipo de documento (DNI/RUC) y ingrese un número.');
             return;
         }
 
@@ -256,6 +256,8 @@ window.addEventListener('load', function() {
     });
 
     // Initial state on page load
-    fetchLongitudAndSetMaxLength();
+    if (!errorModalMessage) {
+        fetchLongitudAndSetMaxLength();
+    }
 });
 </script>


### PR DESCRIPTION
This fixes the final issue with the duplicate assistant validation. A JavaScript initialization function was incorrectly clearing the form fields after they had been repopulated by the server on a validation error. The script is now modified to not run this initialization logic when a validation error is present.