### PR TITLE
Fix: Correct styling and remove session notice on document form

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -1,11 +1,9 @@
 <?php
+// Este archivo es cargado por public/index.php, que ya incluye el header.php.
+// No incluir header.php aquí para evitar duplicar el HTML.
 require_once __DIR__ . '/../database.php';
-session_start();
 
-if (!isset($_SESSION['user_id'])) {
-    header('Location: ../../public/login.php?error=Acceso no autorizado');
-    exit();
-}
+// El router principal (index.php) ya se encarga de la seguridad.
 
 $pdo = getDbConnection();
 $is_edit = isset($_GET['id']);
@@ -430,3 +428,7 @@ document.addEventListener('DOMContentLoaded', function() {
     updateAllCalculations();
 });
 </script>
+<?php
+// Este archivo es cargado por public/index.php, que ya incluye el footer.php.
+// No incluir footer.php aquí para evitar duplicar el HTML.
+?>


### PR DESCRIPTION
- Removed the redundant `session_start()` call in `ingreso_documentos_form.php` to prevent the PHP notice, as the session is already handled by the main `index.php` router.
- Removed the unnecessary authentication check from the form page, as this is also handled by the main router.
- This ensures the form is loaded correctly within the main site template, inheriting the project's CSS styles as intended.