### PR TITLE
Fix: Resolve database error and unify styling

### DIFF
--- a/src/database.php
+++ b/src/database.php
@@ -24,7 +24,7 @@ function getDbConnection() {
         $options = [
             PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-            PDO::ATTR_EMULATE_PREPARES   => false,
+            PDO::ATTR_EMULATE_PREPARES   => true,
         ];
 
         try {


### PR DESCRIPTION
- Set `PDO::ATTR_EMULATE_PREPARES` to `true` in `database.php` to fix a 'MySQL server has gone away' error that occurred when calling multiple stored procedures on the document edit form.
- Added Bootstrap CSS and JS to the main layout to provide consistent styling, resolving an issue where the document form appeared unstyled.
- Removed redundant session and layout code from `ingreso_documentos_form.php`.