### PR TITLE
feat: Agregar centro de costo a nivel de detalle del documento

### DIFF
--- a/database/20250909_add_cc_to_details.sql
+++ b/database/20250909_add_cc_to_details.sql
@@ -1,0 +1,121 @@
+-- =================================================================
+-- PARCHE PARA AÑADIR CENTRO DE COSTO AL DETALLE DE DOCUMENTOS
+-- Fecha: 2025-09-09
+-- Autor: Jules AI
+-- Descripción: Este script añade la columna id_centro_costo a la
+-- tabla documentos_detalle y actualiza los SPs correspondientes.
+-- =================================================================
+
+-- =================================================================
+-- SECCIÓN 1: Modificaciones de Tablas
+-- =================================================================
+
+-- Desc: Añade la columna `id_centro_costo` a `documentos_detalle`.
+DELIMITER $$
+CREATE PROCEDURE `patch_add_cc_to_detalle`()
+BEGIN
+    IF NOT EXISTS (SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'documentos_detalle' AND COLUMN_NAME = 'id_centro_costo') THEN
+        ALTER TABLE `documentos_detalle`
+        ADD COLUMN `id_centro_costo` INT NULL AFTER `id_concepto`,
+        ADD CONSTRAINT `fk_detalle_centro_costo` FOREIGN KEY (`id_centro_costo`) REFERENCES `centros_costos`(`id`);
+    END IF;
+END$$
+DELIMITER ;
+CALL patch_add_cc_to_detalle();
+DROP PROCEDURE patch_add_cc_to_detalle;
+
+
+-- =================================================================
+-- SECCIÓN 2: Procedimientos Almacenados (SPs)
+-- =================================================================
+
+-- SP para crear detalle de documento
+DROP PROCEDURE IF EXISTS sp_create_documento_detalle;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_documento_detalle`(
+    IN p_id_documento INT,
+    IN p_item INT,
+    IN p_cantidad DECIMAL(15, 4),
+    IN p_descripcion VARCHAR(255),
+    IN p_id_concepto INT,
+    IN p_id_centro_costo INT, -- Nueva columna
+    IN p_precio_unitario DECIMAL(15, 4),
+    IN p_precio_total DECIMAL(15, 2),
+    IN p_total_soles DECIMAL(15, 2),
+    IN p_total_dolares DECIMAL(15, 2)
+)
+BEGIN
+    INSERT INTO documentos_detalle (
+        id_documento,
+        item,
+        cantidad,
+        descripcion,
+        id_concepto,
+        id_centro_costo, -- Nueva columna
+        precio_unitario,
+        precio_total,
+        total_soles,
+        total_dolares
+    ) VALUES (
+        p_id_documento,
+        p_item,
+        p_cantidad,
+        p_descripcion,
+        p_id_concepto,
+        p_id_centro_costo, -- Nueva columna
+        p_precio_unitario,
+        p_precio_total,
+        p_total_soles,
+        p_total_dolares
+    );
+END$$
+DELIMITER ;
+
+-- SP para leer detalle de documento por ID de documento
+DROP PROCEDURE IF EXISTS sp_read_documento_detalle_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_documento_detalle_by_id`(IN p_id_documento INT)
+BEGIN
+    SELECT
+        dd.*,
+        cc.nombre AS centro_costo_nombre -- Opcional: unirse para obtener el nombre para la UI si es necesario
+    FROM
+        documentos_detalle dd
+    LEFT JOIN
+        centros_costos cc ON dd.id_centro_costo = cc.id
+    WHERE
+        dd.id_documento = p_id_documento
+    ORDER BY
+        dd.item ASC;
+END$$
+DELIMITER ;
+
+-- SP para leer todos los documentos (actualizar la vista principal)
+DROP PROCEDURE IF EXISTS sp_read_all_documentos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_documentos`()
+BEGIN
+    SELECT
+        d.id,
+        d.fecha_emision,
+        td.nombre as tipo_documento,
+        d.serie_documento,
+        d.numero_documento,
+        a.razon_social_nombres as auxiliar,
+        cc.nombre as centro_costo, -- Añadido para la vista principal
+        d.moneda,
+        d.total,
+        d.total_soles,
+        d.total_dolares
+    FROM
+        documentos d
+    JOIN
+        tipos_documento td ON d.id_tipo_documento = td.id
+    JOIN
+        auxiliares a ON d.id_auxiliar = a.id
+    LEFT JOIN
+        centros_costos cc ON d.id_centro_costo = cc.id -- LEFT JOIN por si no tiene CC
+    ORDER BY
+        d.fecha_emision DESC, d.id DESC;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -68,13 +68,14 @@ try {
             }
 
             // Insert new details for both create and update
-            $stmt_insert_detail = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt_insert_detail = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             foreach ($details as $index => $item) {
                 $item_total = (float)$item['cantidad'] * (float)$item['precio_unitario'];
                 $item_total_soles = $is_soles ? $item_total : $item_total * $tc;
                 $item_total_dolares = !$is_soles ? $item_total : $item_total / $tc;
-                $descripcion = $item['descripcion'] ?? ''; // Get description from item
-                $stmt_insert_detail->execute([$doc_id, $index + 1, $item['cantidad'], $descripcion, $item['id_concepto'], $item['precio_unitario'], $item_total, $item_total_soles, $item_total_dolares]);
+                $descripcion = $item['descripcion'] ?? '';
+                $id_centro_costo = $item['id_centro_costo'] ?? null; // Get CC from item
+                $stmt_insert_detail->execute([$doc_id, $index + 1, $item['cantidad'], $descripcion, $item['id_concepto'], $id_centro_costo, $item['precio_unitario'], $item_total, $item_total_soles, $item_total_dolares]);
             }
             break;
 

--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -41,6 +41,7 @@ try {
                 <th>Tipo Documento</th>
                 <th>Serie y Número</th>
                 <th>Auxiliar</th>
+                <th>Centro de Costo</th>
                 <th>Moneda</th>
                 <th>Total</th>
                 <th>Acciones</th>
@@ -59,6 +60,7 @@ try {
                     <td><?= htmlspecialchars($doc['tipo_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['serie_documento'] . '-' . $doc['numero_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['auxiliar']) ?></td>
+                    <td><?= htmlspecialchars($doc['centro_costo']) ?></td>
                     <td><?= htmlspecialchars($doc['moneda']) ?></td>
                     <td style="text-align: right;"><?= htmlspecialchars(number_format($doc['total'], 2)) ?></td>
                     <td>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -138,8 +138,9 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                             <tr>
                                 <th style="width: 5%;">#</th>
                                 <th style="width: 10%;">Cant.</th>
-                                <th style="width: 30%;">Concepto</th>
-                                <th style="width: 30%;">Descripción</th>
+                                <th style="width: 25%;">Concepto</th>
+                                <th style="width: 20%;">Descripción</th>
+                                <th style="width: 15%;">CC</th>
                                 <th style="width: 10%;">P. Unit.</th>
                                 <th style="width: 10%;">Total</th>
                                 <th style="width: 5%;">Acción</th>
@@ -201,6 +202,13 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
             </select>
         </td>
         <td><input type="text" class="form-control form-control-sm" name="descripcion"></td>
+        <td>
+            <select class="form-select form-select-sm" name="id_centro_costo" required>
+                <?php foreach($centros_costo as $cc): ?>
+                <option value="<?= $cc['id'] ?>"><?= htmlspecialchars($cc['nombre']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </td>
         <td><input type="number" class="form-control form-control-sm" name="precio_unitario" step="0.0001" required></td>
         <td><input type="text" class="form-control form-control-sm total-row" name="precio_total" readonly></td>
         <td><button type="button" class="btn btn-sm btn-danger removeRowBtn">X</button></td>
@@ -216,6 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const rowTemplate = document.getElementById('detalleRowTemplate');
 
     // Header fields
+    const headerCentroCostoSelect = document.getElementById('id_centro_costo');
     const proyectoSelect = document.getElementById('id_proyecto');
     const subProyectoSelect = document.getElementById('id_sub_proyecto');
     const fechaInput = document.getElementById('fecha_emision');
@@ -246,12 +255,24 @@ document.addEventListener('DOMContentLoaded', function() {
         const priceInput = tr.querySelector('[name="precio_unitario"]');
         const conceptSelect = tr.querySelector('[name="id_concepto"]');
         const descInput = tr.querySelector('[name="descripcion"]');
+        const centroCostoSelect = tr.querySelector('[name="id_centro_costo"]');
 
         if (detail) {
+            // Populate from existing data in edit mode
             qtyInput.value = detail.cantidad;
             priceInput.value = detail.precio_unitario;
             conceptSelect.value = detail.id_concepto;
             descInput.value = detail.descripcion || '';
+            // Set the cost center from the detail data
+            if (detail.id_centro_costo) {
+                centroCostoSelect.value = detail.id_centro_costo;
+            }
+        } else {
+            // Set default from header for new rows
+            const headerCentroCostoId = headerCentroCostoSelect.value;
+            if (headerCentroCostoId) {
+                centroCostoSelect.value = headerCentroCostoId;
+            }
         }
 
         tr.querySelector('.removeRowBtn').addEventListener('click', () => {


### PR DESCRIPTION
Este commit introduce la funcionalidad de centro de costo (CC) a nivel de línea de detalle en los documentos.

- Se añade la columna `id_centro_costo` a la tabla `documentos_detalle`.
- Se actualizan los procedimientos almacenados (`sp_create_documento_detalle`, `sp_read_documento_detalle_by_id`, `sp_read_all_documentos`) para soportar esta nueva columna.
- En el formulario de ingreso de documentos, se añade una columna "CC" a la grilla de detalles.
- Al agregar una nueva fila de detalle, el centro de costo se copia por defecto del que está seleccionado en la cabecera del documento.
- El usuario puede modificar el centro de costo para cada línea de detalle de forma individual.
- La vista principal de documentos ahora muestra el centro de costo de la cabecera.