### PR TITLE
fix: Asegurar commit en la eliminación de documentos

### DIFF
--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -1,5 +1,4 @@
 <?php
-header('Content-Type: application/json');
 session_start();
 require_once __DIR__ . '/../database.php';
 
@@ -84,6 +83,7 @@ try {
             $doc_id = $_GET['id'];
             $stmt_delete = $pdo->prepare("CALL sp_delete_documento(?)");
             $stmt_delete->execute([$doc_id]);
+            $pdo->commit(); // Commit the transaction before redirecting
             // Since this is called via a link, we redirect instead of returning JSON
             header('Location: ../../public/index.php?page=ingreso_documentos&success=' . urlencode('Documento eliminado con éxito.'));
             exit();
@@ -103,5 +103,6 @@ try {
     http_response_code(500);
 }
 
+header('Content-Type: application/json');
 echo json_encode($response);
 ?>


### PR DESCRIPTION
Se ha corregido un error que impedía que los documentos se eliminaran correctamente de la base de datos.

El problema era que la transacción de la base de datos no se confirmaba (`commit`) antes de que el script finalizara durante la operación de eliminación. Esto causaba que la base de datos revirtiera la eliminación.

La solución consiste en:
1.  Añadir una llamada explícita a `$pdo->commit()` en el caso 'delete' del archivo `src/actions/documentos_process.php` antes de la redirección.
2.  Mover el encabezado `Content-Type: application/json` al final del script para evitar conflictos de encabezado con la redirección de la operación de eliminación.