### PR TITLE
feat: Añadir validación de documentos duplicados y ajustar UI

### DIFF
--- a/database/20250909_add_sp_check_duplicate_doc.sql
+++ b/database/20250909_add_sp_check_duplicate_doc.sql
@@ -1,0 +1,34 @@
+-- =================================================================
+-- PARCHE PARA AÑADIR SP DE VALIDACIÓN DE DOCUMENTOS DUPLICADOS
+-- Fecha: 2025-09-09
+-- Autor: Jules AI
+-- Descripción: Este script añade el procedimiento almacenado
+-- `sp_check_documento_duplicado` para verificar la existencia de
+-- un documento antes de su creación o actualización.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_check_documento_duplicado;
+DELIMITER $$
+CREATE PROCEDURE `sp_check_documento_duplicado`(
+    IN p_id_tipo_documento INT,
+    IN p_serie_documento VARCHAR(10),
+    IN p_numero_documento VARCHAR(20),
+    IN p_id_auxiliar INT,
+    IN p_id_documento INT -- Opcional: para excluir el documento actual en una actualización
+)
+BEGIN
+    SELECT
+        id,
+        serie_documento,
+        numero_documento
+    FROM
+        documentos
+    WHERE
+        id_tipo_documento = p_id_tipo_documento
+        AND serie_documento = p_serie_documento
+        AND numero_documento = p_numero_documento
+        AND id_auxiliar = p_id_auxiliar
+        AND (p_id_documento IS NULL OR id != p_id_documento)
+    LIMIT 1;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -36,6 +36,26 @@ try {
                 throw new Exception('Datos del formulario inválidos o incompletos.');
             }
 
+            // -- Validación de Duplicados --
+            $doc_id_to_check = !empty($header['id_documento']) ? $header['id_documento'] : null;
+            $stmt_check = $pdo->prepare("CALL sp_check_documento_duplicado(?, ?, ?, ?, ?)");
+            $stmt_check->execute([
+                $header['id_tipo_documento'],
+                $header['serie_documento'],
+                $header['numero_documento'],
+                $header['id_auxiliar'],
+                $doc_id_to_check
+            ]);
+            $duplicate = $stmt_check->fetch(PDO::FETCH_ASSOC);
+            $stmt_check->closeCursor();
+
+            if ($duplicate) {
+                $message = "El documento " . htmlspecialchars($duplicate['serie_documento']) . "-" . htmlspecialchars($duplicate['numero_documento']) . " ya existe para este auxiliar.";
+                throw new Exception($message);
+            }
+            // -- Fin Validación --
+
+
             // Server-side Calculation and Validation
             $subtotal = 0;
             foreach ($details as $item) {

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -75,7 +75,9 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                             <label for="fecha_emision" class="form-label">Fecha Emisión</label>
                             <input type="date" class="form-control" id="fecha_emision" name="fecha_emision" value="<?= htmlspecialchars($header['fecha_emision'] ?? date('Y-m-d')) ?>" required>
                         </div>
-                         <div class="col-md-3 mb-3">
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
                             <label for="id_auxiliar" class="form-label">Auxiliar</label>
                             <select class="form-select" id="id_auxiliar" name="id_auxiliar" required>
                                  <option value="">Seleccione</option>


### PR DESCRIPTION
Este commit introduce dos cambios principales solicitados por el usuario:
1.  Validación para prevenir el registro de documentos duplicados.
2.  Un ajuste en la disposición de los campos del formulario de documentos.

**Validación de Duplicados:**
- Se ha creado un nuevo procedimiento almacenado `sp_check_documento_duplicado` que verifica la existencia de un documento basado en su tipo, serie, número y auxiliar.
- La lógica del backend en `documentos_process.php` ahora utiliza este SP antes de crear o actualizar un documento.
- Si se detecta un duplicado, el proceso se detiene y se devuelve un error al frontend.
- El frontend mostrará este error en un mensaje emergente.

**Ajuste de UI:**
- En el formulario `ingreso_documentos_form.php`, el campo "Auxiliar" ha sido movido a su propia fila, justo antes de la fila de "Proyecto", para mejorar la estructura visual y el flujo de entrada de datos.