### PR TITLE
refactor: Reordenar campos en el formulario de documentos

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -55,7 +55,7 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                 <fieldset class="border p-3 mb-4">
                     <legend class="w-auto px-2 h6">Encabezado</legend>
                     <div class="row">
-                        <div class="col-md-3 mb-3">
+                        <div class="col-md-2 mb-3">
                             <label for="id_tipo_documento" class="form-label">Tipo Documento</label>
                             <select class="form-select" id="id_tipo_documento" name="id_tipo_documento" required>
                                 <?php foreach($tipos_documento as $tipo): ?>
@@ -72,8 +72,19 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                             <input type="text" class="form-control" id="numero_documento" name="numero_documento" value="<?= htmlspecialchars($header['numero_documento'] ?? '') ?>" required>
                         </div>
                         <div class="col-md-2 mb-3">
+                            <label for="moneda" class="form-label">Moneda</label>
+                            <select class="form-select" id="moneda" name="moneda" required>
+                                <option value="SOLES" <?= ($header && $header['moneda'] == 'SOLES') ? 'selected' : '' ?>>Soles (S/)</option>
+                                <option value="DOLARES" <?= ($header && $header['moneda'] == 'DOLARES') ? 'selected' : '' ?>>Dólares ($)</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2 mb-3">
                             <label for="fecha_emision" class="form-label">Fecha Emisión</label>
                             <input type="date" class="form-control" id="fecha_emision" name="fecha_emision" value="<?= htmlspecialchars($header['fecha_emision'] ?? date('Y-m-d')) ?>" required>
+                        </div>
+                        <div class="col-md-2 mb-3">
+                            <label for="tipo_cambio" class="form-label">Tipo Cambio</label>
+                            <input type="number" step="0.0001" class="form-control" id="tipo_cambio" name="tipo_cambio" value="<?= htmlspecialchars($header['tipo_cambio'] ?? '1.0000') ?>" required>
                         </div>
                     </div>
                     <div class="row">
@@ -114,18 +125,7 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                         </div>
                     </div>
                      <div class="row">
-                        <div class="col-md-2 mb-3">
-                            <label for="moneda" class="form-label">Moneda</label>
-                            <select class="form-select" id="moneda" name="moneda" required>
-                                <option value="SOLES" <?= ($header && $header['moneda'] == 'SOLES') ? 'selected' : '' ?>>Soles (S/)</option>
-                                <option value="DOLARES" <?= ($header && $header['moneda'] == 'DOLARES') ? 'selected' : '' ?>>Dólares ($)</option>
-                            </select>
-                        </div>
-                        <div class="col-md-2 mb-3">
-                            <label for="tipo_cambio" class="form-label">Tipo Cambio</label>
-                            <input type="number" step="0.0001" class="form-control" id="tipo_cambio" name="tipo_cambio" value="<?= htmlspecialchars($header['tipo_cambio'] ?? '1.0000') ?>" required>
-                        </div>
-                         <div class="col-md-8 mb-3">
+                         <div class="col-md-12 mb-3">
                             <label for="glosa" class="form-label">Glosa</label>
                             <input type="text" class="form-control" id="glosa" name="glosa" value="<?= htmlspecialchars($header['glosa'] ?? '') ?>" required>
                         </div>


### PR DESCRIPTION
Se ha reestructurado el layout del formulario de ingreso de documentos para mejorar el flujo de entrada de datos y la usabilidad, según las especificaciones del usuario.

Cambios realizados en `src/pages/ingreso_documentos_form.php`:
- La fila principal de campos ahora sigue el orden: Tipo de Documento, Serie, Número, Moneda, Fecha de Emisión y Tipo de Cambio.
- Los campos 'Moneda' y 'Tipo de Cambio' fueron movidos desde una fila inferior a esta fila principal.
- Se ajustaron las clases de la grilla de Bootstrap (`col-md-*`) para que todos los campos se alineen correctamente en una sola fila.
- El campo 'Glosa' ahora ocupa una fila completa (`col-md-12`), lo que proporciona más espacio para el texto.