### PR TITLE
refactor: Usar modal personalizado para alertas de validación

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -427,7 +427,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (data.success) {
                 window.location.href = `index.php?page=ingreso_documentos&success=${encodeURIComponent(data.message)}`;
             } else {
-                alert(`Error: ${data.message}`); // Replace with a proper modal later
+                showAlertModal(data.message); // Use the custom modal for errors
                 document.getElementById('submitBtn').disabled = false;
                 document.getElementById('submitBtn').textContent = 'Guardar Documento';
             }


### PR DESCRIPTION
Se ha actualizado el formulario de ingreso de documentos para utilizar la ventana emergente (modal) personalizada de la aplicación en lugar de la alerta estándar del navegador para mostrar mensajes de error de validación.

- Se modificó el script en `src/pages/ingreso_documentos_form.php`.
- La llamada a `alert()` fue reemplazada por `showAlertModal(data.message)`.
- Esto asegura una experiencia de usuario consistente con el resto de la aplicación, mostrando los errores de validación (como documentos duplicados) en el modal estandarizado.