### PR TITLE
fix: Cambiar color del texto del botón del modal a blanco

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -127,5 +127,6 @@ body {
 
 .modal-content button {
     background-color: #005cb3;
+    color: #ffffff;
     min-width: 100px;
 }


### PR DESCRIPTION
Se ha modificado el estilo del botón 'Aceptar' en la ventana emergente personalizada para que el texto sea de color blanco, mejorando la legibilidad sobre el fondo azul.

- Se actualizó la regla `.modal-content button` en `public/css/style.css`.
- Se añadió la propiedad `color: #ffffff;` para asegurar el contraste del texto.