### PR TITLE
refactor: Eliminar leyendas de fieldset en el formulario de documentos

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -53,7 +53,6 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
 
                 <!-- Encabezado del Documento -->
                 <fieldset class="border p-3 mb-4">
-                    <legend class="w-auto px-2 h6">Encabezado</legend>
                     <div class="row">
                         <div class="col-md-2 mb-3">
                             <label for="id_tipo_documento" class="form-label">Tipo Documento</label>
@@ -134,7 +133,6 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
 
                 <!-- Detalle del Documento -->
                 <fieldset class="border p-3 mb-4">
-                    <legend class="w-auto px-2 h6">Detalle</legend>
                     <table class="table table-sm table-bordered">
                         <thead class="table-light">
                             <tr>


### PR DESCRIPTION
Se han eliminado los textos "Encabezado" y "Detalle" del formulario de ingreso de documentos para simplificar la interfaz de usuario, según lo solicitado.

- Se modificó `src/pages/ingreso_documentos_form.php`.
- Se eliminaron las etiquetas `<legend>` de los dos principales `<fieldset>` del formulario.