### PR TITLE
feat: Añadir filtros a la página de Ingreso de Documentos

### DIFF
--- a/database/20250909_add_filters_to_documentos.sql
+++ b/database/20250909_add_filters_to_documentos.sql
@@ -1,0 +1,52 @@
+-- =================================================================
+-- PARCHE PARA AÑADIR FILTROS A LA VISTA DE DOCUMENTOS
+-- Fecha: 2025-09-09
+-- Autor: Jules AI
+-- Descripción: Este script modifica el SP `sp_read_all_documentos`
+-- para que acepte parámetros de filtrado.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_all_documentos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_documentos`(
+    IN p_fecha_desde DATE,
+    IN p_fecha_hasta DATE,
+    IN p_id_tipo_documento INT,
+    IN p_serie_numero VARCHAR(31),
+    IN p_auxiliar VARCHAR(255),
+    IN p_id_centro_costo INT,
+    IN p_moneda VARCHAR(10)
+)
+BEGIN
+    SELECT
+        d.id,
+        d.fecha_emision,
+        td.nombre as tipo_documento,
+        d.serie_documento,
+        d.numero_documento,
+        a.razon_social_nombres as auxiliar,
+        cc.nombre as centro_costo,
+        d.moneda,
+        d.total,
+        d.total_soles,
+        d.total_dolares
+    FROM
+        documentos d
+    JOIN
+        tipos_documento td ON d.id_tipo_documento = td.id
+    JOIN
+        auxiliares a ON d.id_auxiliar = a.id
+    LEFT JOIN
+        centros_costos cc ON d.id_centro_costo = cc.id
+    WHERE
+        (p_fecha_desde IS NULL OR d.fecha_emision >= p_fecha_desde)
+        AND (p_fecha_hasta IS NULL OR d.fecha_emision <= p_fecha_hasta)
+        AND (p_id_tipo_documento IS NULL OR p_id_tipo_documento = '' OR d.id_tipo_documento = p_id_tipo_documento)
+        AND (p_serie_numero IS NULL OR p_serie_numero = '' OR CONCAT(d.serie_documento, '-', d.numero_documento) LIKE CONCAT('%', p_serie_numero, '%'))
+        AND (p_auxiliar IS NULL OR p_auxiliar = '' OR a.razon_social_nombres LIKE CONCAT('%', p_auxiliar, '%'))
+        AND (p_id_centro_costo IS NULL OR p_id_centro_costo = '' OR d.id_centro_costo = p_id_centro_costo)
+        AND (p_moneda IS NULL OR p_moneda = '' OR d.moneda = p_moneda)
+    ORDER BY
+        d.fecha_emision DESC, d.id DESC;
+END$$
+DELIMITER ;

--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -1,17 +1,44 @@
 <?php
 require_once __DIR__ . '/../database.php';
 
+// Obtener valores de filtro de la URL
+$f_fecha_desde = $_GET['fecha_desde'] ?? null;
+$f_fecha_hasta = $_GET['fecha_hasta'] ?? null;
+$f_id_tipo_documento = $_GET['id_tipo_documento'] ?? null;
+$f_serie_numero = $_GET['serie_numero'] ?? null;
+$f_auxiliar = $_GET['auxiliar'] ?? null;
+$f_id_centro_costo = $_GET['id_centro_costo'] ?? null;
+$f_moneda = $_GET['moneda'] ?? null;
+
 $documentos = [];
 try {
     $pdo = getDbConnection();
-    $stmt = $pdo->prepare("CALL sp_read_all_documentos()");
-    $stmt->execute();
-    $documentos = $stmt->fetchAll();
+
+    // Obtener datos para los dropdowns de los filtros
+    $tipos_documento_list = $pdo->query("CALL sp_read_tipos_documento_for_dropdown()")->fetchAll(PDO::FETCH_ASSOC);
+    $centros_costo_list = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetchAll(PDO::FETCH_ASSOC);
+
+    // Llamar al SP con los filtros
+    $stmt = $pdo->prepare("CALL sp_read_all_documentos(?, ?, ?, ?, ?, ?, ?)");
+    $stmt->execute([
+        empty($f_fecha_desde) ? null : $f_fecha_desde,
+        empty($f_fecha_hasta) ? null : $f_fecha_hasta,
+        empty($f_id_tipo_documento) ? null : $f_id_tipo_documento,
+        empty($f_serie_numero) ? null : $f_serie_numero,
+        empty($f_auxiliar) ? null : $f_auxiliar,
+        empty($f_id_centro_costo) ? null : $f_id_centro_costo,
+        empty($f_moneda) ? null : $f_moneda
+    ]);
+    $documentos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
 } catch (PDOException $e) {
     // Si el SP no existe, no es un error fatal, la tabla simplemente estará vacía.
     // En un futuro, se podría manejar este error de forma más explícita.
     if ($e->getCode() !== '42000') { // 42000 es el código para 'Syntax error or access violation'
       die("Error al obtener los documentos: " . $e->getMessage());
+    } else {
+      // Potentially handle the case where the old SP without filters is still in use
+      $documentos = [];
     }
 }
 ?>
@@ -25,6 +52,12 @@ try {
     .btn-edit { background-color: #ffc107; }
     .btn-delete { background-color: #dc3545; }
     .btn-add { background-color: #28a745; display: inline-block; margin-bottom: 20px; }
+    .filter-form { background-color: #eef; padding: 15px; border-radius: 8px; margin-bottom: 20px; display: flex; flex-wrap: wrap; gap: 15px; align-items: flex-end; }
+    .filter-form .form-group { display: flex; flex-direction: column; }
+    .filter-form .form-group label { margin-bottom: 5px; font-weight: bold; }
+    .filter-form .form-group input, .filter-form .form-group select { padding: 8px; border: 1px solid #ddd; border-radius: 4px; }
+    .btn-filter { background-color: #005cb3; color: white; padding: 8px 15px; border: none; border-radius: 4px; cursor: pointer; }
+    .btn-clear { background-color: #6c757d; }
 </style>
 
 <header>
@@ -32,6 +65,56 @@ try {
 </header>
 <section>
     <a href="index.php?page=ingreso_documentos_form" class="btn btn-add">Añadir Nuevo Documento</a>
+
+    <form action="index.php" method="GET" class="filter-form">
+        <input type="hidden" name="page" value="ingreso_documentos">
+
+        <div class="form-group">
+            <label for="fecha_desde">Fecha Desde</label>
+            <input type="date" id="fecha_desde" name="fecha_desde" value="<?= htmlspecialchars($f_fecha_desde ?? '') ?>">
+        </div>
+        <div class="form-group">
+            <label for="fecha_hasta">Fecha Hasta</label>
+            <input type="date" id="fecha_hasta" name="fecha_hasta" value="<?= htmlspecialchars($f_fecha_hasta ?? '') ?>">
+        </div>
+        <div class="form-group">
+            <label for="tipo_documento">Tipo Documento</label>
+            <select id="tipo_documento" name="id_tipo_documento">
+                <option value="">Todos</option>
+                <?php foreach($tipos_documento_list as $tipo): ?>
+                    <option value="<?= $tipo['id'] ?>" <?= (($f_id_tipo_documento ?? null) == $tipo['id']) ? 'selected' : '' ?>><?= htmlspecialchars($tipo['nombre']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="serie_numero">Serie-Número</label>
+            <input type="text" id="serie_numero" name="serie_numero" value="<?= htmlspecialchars($f_serie_numero ?? '') ?>" placeholder="Ej: F001-123">
+        </div>
+        <div class="form-group">
+            <label for="auxiliar">Auxiliar</label>
+            <input type="text" id="auxiliar" name="auxiliar" value="<?= htmlspecialchars($f_auxiliar ?? '') ?>">
+        </div>
+        <div class="form-group">
+            <label for="centro_costo">Centro de Costo</label>
+            <select id="centro_costo" name="id_centro_costo">
+                <option value="">Todos</option>
+                 <?php foreach($centros_costo_list as $cc): ?>
+                    <option value="<?= $cc['id'] ?>" <?= (($f_id_centro_costo ?? null) == $cc['id']) ? 'selected' : '' ?>><?= htmlspecialchars($cc['nombre']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="moneda">Moneda</label>
+            <select id="moneda" name="moneda">
+                <option value="">Todas</option>
+                <option value="SOLES" <?= (($f_moneda ?? null) == 'SOLES') ? 'selected' : '' ?>>Soles</option>
+                <option value="DOLARES" <?= (($f_moneda ?? null) == 'DOLARES') ? 'selected' : '' ?>>Dólares</option>
+            </select>
+        </div>
+
+        <button type="submit" class="btn btn-filter">Filtrar</button>
+        <a href="index.php?page=ingreso_documentos" class="btn btn-clear">Limpiar</a>
+    </form>
 
     <table class="table">
         <thead>


### PR DESCRIPTION
Se ha implementado una sección de filtros en la página de listado de 'Ingreso de Documentos', siguiendo el estándar de las demás páginas de mantenimiento de la aplicación.

- Se ha modificado el procedimiento almacenado `sp_read_all_documentos` para que acepte parámetros de filtrado (rango de fechas, tipo de doc, serie/número, auxiliar, centro de costo y moneda).
- Se ha añadido un formulario GET en `src/pages/ingreso_documentos.php` con campos de entrada para cada filtro.
- La lógica PHP en la página se ha actualizado para leer los parámetros del filtro, pasarlos al SP y mantener los valores en los campos del formulario después de la búsqueda.
- Se han añadido estilos CSS para el formulario de filtros, reutilizando las clases existentes para mantener la consistencia visual.