### PR TITLE
feat: Make auxiliar combo box searchable

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -5,8 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sistema de Gestión de ONG</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
 </head>
 <body>
     <div class="container">

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -471,6 +471,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     updateAllCalculations();
     updateTotalsVisibility(); // Call this on initial load
+
+    new TomSelect("#id_auxiliar",{
+        create: true,
+        sortField: {
+            field: "text",
+            direction: "asc"
+        }
+    });
 });
 </script>
 <?php


### PR DESCRIPTION
- Implemented Tom Select library to transform the 'auxiliar' combo box into a searchable and editable dropdown.
- Added Tom Select CSS and JS from a CDN to the main header.
- Initialized Tom Select on the '#id_auxiliar' element in the document form.
- This change improves user experience by allowing users to either search for an existing 'auxiliar' or create a new one on the fly.