### PR TITLE
fix: Make collapsible sidebar icon-only when collapsed

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -38,14 +38,29 @@ body {
 
 /* Collapsed Sidebar Styles */
 body.sidebar-collapsed .sidebar {
-    width: 0;
-    padding-top: 0;
-    overflow: hidden;
+    width: 80px;
 }
 
-body.sidebar-collapsed .sidebar .logo,
-body.sidebar-collapsed .sidebar nav {
+body.sidebar-collapsed .sidebar .logo-text,
+body.sidebar-collapsed .sidebar .sidebar-item-text,
+body.sidebar-collapsed .sidebar .float-indicator {
     display: none;
+}
+
+body.sidebar-collapsed .sidebar .logo {
+    justify-content: center;
+}
+
+body.sidebar-collapsed .sidebar .logo .btn {
+    margin-right: 0;
+}
+
+body.sidebar-collapsed .sidebar nav ul li a {
+    justify-content: center;
+}
+
+body.sidebar-collapsed .sidebar nav ul li a i {
+    margin-right: 0;
 }
 
 .sidebar nav ul {
@@ -100,6 +115,7 @@ body.sidebar-collapsed .sidebar nav {
 .main-content {
     flex-grow: 1;
     padding: 20px;
+    transition: margin-left 0.3s ease;
 }
 
 .main-content header {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -42,6 +42,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (sidebarToggleBtn) {
         sidebarToggleBtn.addEventListener('click', () => {
             body.classList.toggle('sidebar-collapsed');
+            const icon = sidebarToggleBtn.querySelector('i');
+            if (body.classList.contains('sidebar-collapsed')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
         });
     }
 });

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -17,38 +17,38 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="index.php?page=inicio"><i class="fas fa-home"></i> Inicio</a></li>
+                    <li><a href="index.php?page=inicio"><i class="fas fa-home"></i><span class="sidebar-item-text"> Inicio</span></a></li>
                     <li>
                         <a href="#mantenimientoSubmenu" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
-                            <span><i class="fas fa-cogs"></i> Mantenimiento</span>
+                            <div><i class="fas fa-cogs"></i><span class="sidebar-item-text"> Mantenimiento</span></div>
                             <i class="fas fa-chevron-down float-indicator"></i>
                         </a>
                         <ul class="collapse list-unstyled" id="mantenimientoSubmenu">
-                            <li><a href="index.php?page=proyectos">Proyectos</a></li>
-                            <li><a href="index.php?page=sub_proyectos">Sub Proyectos</a></li>
-                            <li><a href="index.php?page=centros_costos">Centros de Costos</a></li>
-                            <li><a href="index.php?page=conceptos">Conceptos</a></li>
-                            <li><a href="index.php?page=tipos_documento">Tipos de Documento</a></li>
-                            <li><a href="index.php?page=tipos_documento_identidad">Tipos de Doc. Identidad</a></li>
-                            <li><a href="index.php?page=tipos_auxiliar">Tipos de Auxiliar</a></li>
-                            <li><a href="index.php?page=auxiliares">Auxiliares</a></li>
-                            <li><a href="index.php?page=usuarios">Usuarios</a></li>
-                            <li><a href="index.php?page=tipos_cambio">Tipo de Cambio</a></li>
+                            <li><a href="index.php?page=proyectos"><span class="sidebar-item-text">Proyectos</span></a></li>
+                            <li><a href="index.php?page=sub_proyectos"><span class="sidebar-item-text">Sub Proyectos</span></a></li>
+                            <li><a href="index.php?page=centros_costos"><span class="sidebar-item-text">Centros de Costos</span></a></li>
+                            <li><a href="index.php?page=conceptos"><span class="sidebar-item-text">Conceptos</span></a></li>
+                            <li><a href="index.php?page=tipos_documento"><span class="sidebar-item-text">Tipos de Documento</span></a></li>
+                            <li><a href="index.php?page=tipos_documento_identidad"><span class="sidebar-item-text">Tipos de Doc. Identidad</span></a></li>
+                            <li><a href="index.php?page=tipos_auxiliar"><span class="sidebar-item-text">Tipos de Auxiliar</span></a></li>
+                            <li><a href="index.php?page=auxiliares"><span class="sidebar-item-text">Auxiliares</span></a></li>
+                            <li><a href="index.php?page=usuarios"><span class="sidebar-item-text">Usuarios</span></a></li>
+                            <li><a href="index.php?page=tipos_cambio"><span class="sidebar-item-text">Tipo de Cambio</span></a></li>
                         </ul>
                     </li>
                     <li>
                         <a href="#operacionesSubmenu" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
-                            <span><i class="fas fa-file-invoice-dollar"></i> Operaciones</span>
+                            <div><i class="fas fa-file-invoice-dollar"></i><span class="sidebar-item-text"> Operaciones</span></div>
                             <i class="fas fa-chevron-down float-indicator"></i>
                         </a>
                         <ul class="collapse list-unstyled" id="operacionesSubmenu">
-                            <li><a href="index.php?page=ingreso_documentos">Ingreso de documentos</a></li>
+                            <li><a href="index.php?page=ingreso_documentos"><span class="sidebar-item-text">Ingreso de documentos</span></a></li>
                         </ul>
                     </li>
-                    <li><a href="index.php?page=reportes"><i class="fas fa-chart-bar"></i> Reportes</a></li>
+                    <li><a href="index.php?page=reportes"><i class="fas fa-chart-bar"></i><span class="sidebar-item-text"> Reportes</span></a></li>
                     <hr>
-                    <li><a href="index.php?page=perfil"><i class="fas fa-user-circle"></i> Mi Perfil</a></li>
-                    <li><a href="../src/actions/logout_process.php"><i class="fas fa-sign-out-alt"></i> Cerrar Sesión</a></li>
+                    <li><a href="index.php?page=perfil"><i class="fas fa-user-circle"></i><span class="sidebar-item-text"> Mi Perfil</span></a></li>
+                    <li><a href="../src/actions/logout_process.php"><i class="fas fa-sign-out-alt"></i><span class="sidebar-item-text"> Cerrar Sesión</span></a></li>
                 </ul>
             </nav>
         </aside>


### PR DESCRIPTION
- Modified the collapsed state of the sidebar to be a smaller, icon-only menu instead of completely hidden.
- This ensures the toggle button is always visible, allowing the user to expand the menu again.
- Updated CSS to handle the new collapsed width and hide text labels.
- Wrapped navigation text in spans to allow them to be targeted by CSS.
- Updated JavaScript to toggle the button's icon between 'bars' and 'times' for better visual feedback.