### PR TITLE
feat: Expand sidebar when submenu is clicked

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -43,12 +43,15 @@ document.addEventListener('DOMContentLoaded', function() {
         sidebarToggleBtn.addEventListener('click', () => {
             body.classList.toggle('sidebar-collapsed');
             const icon = sidebarToggleBtn.querySelector('i');
+            // Check the state *after* toggling
             if (body.classList.contains('sidebar-collapsed')) {
-                icon.classList.remove('fa-bars');
-                icon.classList.add('fa-times');
-            } else {
+                // Now it's collapsed, so show the 'bars' icon
                 icon.classList.remove('fa-times');
                 icon.classList.add('fa-bars');
+            } else {
+                // Now it's expanded, so show the 'times' icon
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
             }
         });
     }

--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -5,10 +5,23 @@
 
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        var dropdowns = document.querySelectorAll('.dropdown-toggle');
+        var dropdowns = document.querySelectorAll('.sidebar .dropdown-toggle');
         dropdowns.forEach(function(dropdown) {
             dropdown.addEventListener('click', function(event) {
                 event.preventDefault();
+
+                // If sidebar is collapsed, expand it first
+                if (document.body.classList.contains('sidebar-collapsed')) {
+                    document.body.classList.remove('sidebar-collapsed');
+                    // Update the main toggle button icon
+                    const sidebarToggleBtn = document.getElementById('sidebarToggleBtn');
+                    if (sidebarToggleBtn) {
+                        const icon = sidebarToggleBtn.querySelector('i');
+                        icon.classList.remove('fa-bars');
+                        icon.classList.add('fa-times');
+                    }
+                }
+
                 var submenu = this.nextElementSibling;
                 var isExpanded = this.getAttribute('aria-expanded') === 'true';
 


### PR DESCRIPTION
- Added JavaScript to the dropdown toggle handler to check if the sidebar is collapsed.
- If the sidebar is collapsed, it is now automatically expanded when a submenu toggle is clicked.
- Corrected the icon logic for the main toggle button to ensure it accurately reflects the sidebar's state at all times ('bars' for collapsed, 'times' for expanded).