### PR TITLE
feat: Add dashboard with charts to home page

### DIFF
--- a/database/20250910_add_dashboard_sprocs.sql
+++ b/database/20250910_add_dashboard_sprocs.sql
@@ -1,0 +1,83 @@
+-- =================================================================
+-- Dashboard Stored Procedures
+-- Fecha: 2025-09-10
+-- Autor: Jules AI
+-- Descripción: Este script contiene los nuevos procedimientos almacenados
+-- para obtener los datos para los gráficos del dashboard.
+-- =================================================================
+
+-- SP para obtener los años con documentos
+DROP PROCEDURE IF EXISTS sp_get_years_with_documents;
+DELIMITER $$
+CREATE PROCEDURE `sp_get_years_with_documents`()
+BEGIN
+    SELECT DISTINCT YEAR(fecha_emision) AS anio
+    FROM documentos
+    ORDER BY anio DESC;
+END$$
+DELIMITER ;
+
+-- SP para el gráfico de barras: Totales por mes y centro de costo
+DROP PROCEDURE IF EXISTS sp_reporte_total_soles_por_mes_y_centro_costo;
+DELIMITER $$
+CREATE PROCEDURE `sp_reporte_total_soles_por_mes_y_centro_costo`(IN p_anio INT)
+BEGIN
+    SELECT
+        MONTH(d.fecha_emision) AS mes,
+        cc.nombre AS nombre_centro_costo,
+        SUM(dd.total_soles) AS total_soles
+    FROM documentos_detalle dd
+    JOIN documentos d ON dd.id_documento = d.id
+    JOIN centros_costos cc ON dd.id_centro_costo = cc.id
+    WHERE YEAR(d.fecha_emision) = p_anio
+    GROUP BY
+        MONTH(d.fecha_emision),
+        cc.nombre
+    ORDER BY
+        mes,
+        nombre_centro_costo;
+END$$
+DELIMITER ;
+
+-- SP para el primer gráfico circular: Totales por mes vs centro de costo
+DROP PROCEDURE IF EXISTS sp_reporte_total_soles_por_mes_vs_centro_costo;
+DELIMITER $$
+CREATE PROCEDURE `sp_reporte_total_soles_por_mes_vs_centro_costo`(IN p_anio INT, IN p_mes INT)
+BEGIN
+    SELECT
+        cc.nombre AS nombre_centro_costo,
+        SUM(dd.total_soles) AS total_soles
+    FROM documentos_detalle dd
+    JOIN documentos d ON dd.id_documento = d.id
+    JOIN centros_costos cc ON dd.id_centro_costo = cc.id
+    WHERE
+        YEAR(d.fecha_emision) = p_anio
+        AND MONTH(d.fecha_emision) = p_mes
+    GROUP BY
+        cc.nombre
+    ORDER BY
+        total_soles DESC;
+END$$
+DELIMITER ;
+
+-- SP para el segundo gráfico circular: Totales por tipo de documento y centro de costo
+DROP PROCEDURE IF EXISTS sp_reporte_total_soles_por_tipo_documento_y_centro_costo;
+DELIMITER $$
+CREATE PROCEDURE `sp_reporte_total_soles_por_tipo_documento_y_centro_costo`(IN p_anio INT, IN p_mes INT, IN p_id_centro_costo INT)
+BEGIN
+    SELECT
+        td.nombre AS nombre_tipo_documento,
+        SUM(dd.total_soles) AS total_soles
+    FROM documentos_detalle dd
+    JOIN documentos d ON dd.id_documento = d.id
+    JOIN tipos_documento td ON d.id_tipo_documento = td.id
+    WHERE
+        YEAR(d.fecha_emision) = p_anio
+        AND MONTH(d.fecha_emision) = p_mes
+        AND dd.id_centro_costo = p_id_centro_costo
+    GROUP BY
+        td.nombre
+    ORDER BY
+        total_soles DESC;
+END$$
+DELIMITER ;

--- a/public/js/inicio_charts.js
+++ b/public/js/inicio_charts.js
@@ -1,0 +1,207 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const filtroAnio = document.getElementById('filtroAnio');
+    const filtroMes = document.getElementById('filtroMes');
+    const filtroCentroCosto = document.getElementById('filtroCentroCosto');
+
+    const ctxBar = document.getElementById('barChart').getContext('2d');
+    const ctxPie1 = document.getElementById('pieChart1').getContext('2d');
+    const ctxPie2 = document.getElementById('pieChart2').getContext('2d');
+
+    let barChart, pieChart1, pieChart2;
+
+    // --- Inicialización de Filtros ---
+
+    function poblarFiltroAnio() {
+        fetch('../src/ajax/get_years.php')
+            .then(response => response.json())
+            .then(data => {
+                data.forEach(item => {
+                    const option = document.createElement('option');
+                    option.value = item.anio;
+                    option.textContent = item.anio;
+                    filtroAnio.appendChild(option);
+                });
+                // Una vez poblado, actualizamos todos los gráficos
+                actualizarGraficos();
+            });
+    }
+
+    function poblarFiltroCentroCosto() {
+        fetch('../src/ajax/get_centros_costos.php')
+            .then(response => response.json())
+            .then(data => {
+                const optionTodos = document.createElement('option');
+                optionTodos.value = '';
+                optionTodos.textContent = 'Todos';
+                filtroCentroCosto.appendChild(optionTodos);
+
+                data.forEach(item => {
+                    const option = document.createElement('option');
+                    option.value = item.id;
+                    option.textContent = item.nombre;
+                    filtroCentroCosto.appendChild(option);
+                });
+            });
+    }
+
+    function setMesActual() {
+        const mesActual = new Date().getMonth() + 1;
+        filtroMes.value = mesActual;
+    }
+
+    // --- Lógica de Gráficos ---
+
+    function actualizarGraficos() {
+        const anio = filtroAnio.value;
+        const mes = filtroMes.value;
+        const idCentroCosto = filtroCentroCosto.value;
+
+        actualizarBarChart(anio);
+        actualizarPieChart1(anio, mes);
+        if (idCentroCosto) {
+            actualizarPieChart2(anio, mes, idCentroCosto);
+        } else {
+            // Si no hay centro de costo seleccionado, limpiar el gráfico 2 o mostrar un mensaje
+            if (pieChart2) pieChart2.destroy();
+        }
+    }
+
+    function actualizarBarChart(anio) {
+        fetch(`../src/ajax/get_reporte_bar_chart.php?anio=${anio}`)
+            .then(response => response.json())
+            .then(data => {
+                if (barChart) barChart.destroy();
+
+                const labels = [...new Set(data.map(item => getMonthName(item.mes)))];
+                const datasets = [];
+                const centrosCosto = [...new Set(data.map(item => item.nombre_centro_costo))];
+
+                centrosCosto.forEach(cc => {
+                    const dataPorCC = labels.map(label => {
+                        const mesNum = getMonthNumber(label);
+                        const item = data.find(d => d.mes == mesNum && d.nombre_centro_costo === cc);
+                        return item ? parseFloat(item.total_soles) : 0;
+                    });
+                    datasets.push({
+                        label: cc,
+                        data: dataPorCC,
+                        backgroundColor: getRandomColor(),
+                    });
+                });
+
+                barChart = new Chart(ctxBar, {
+                    type: 'bar',
+                    data: { labels, datasets },
+                    options: {
+                        scales: {
+                            y: {
+                                beginAtZero: true
+                            }
+                        }
+                    }
+                });
+            });
+    }
+
+    function actualizarPieChart1(anio, mes) {
+        fetch(`../src/ajax/get_reporte_pie_chart1.php?anio=${anio}&mes=${mes}`)
+            .then(response => response.json())
+            .then(data => {
+                if (pieChart1) pieChart1.destroy();
+
+                const labels = data.map(item => item.nombre_centro_costo);
+                const importes = data.map(item => parseFloat(item.total_soles));
+
+                pieChart1 = new Chart(ctxPie1, {
+                    type: 'pie',
+                    data: {
+                        labels,
+                        datasets: [{
+                            data: importes,
+                            backgroundColor: labels.map(() => getRandomColor()),
+                        }]
+                    },
+                    options: {
+                        plugins: {
+                            tooltip: {
+                                callbacks: {
+                                    label: function(context) {
+                                        let label = context.label || '';
+                                        let value = context.raw || 0;
+                                        let total = context.chart.getDatasetMeta(0).total;
+                                        let percentage = ((value / total) * 100).toFixed(2);
+                                        return `${label}: S/ ${value.toFixed(2)} (${percentage}%)`;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+    }
+
+    function actualizarPieChart2(anio, mes, idCentroCosto) {
+        fetch(`../src/ajax/get_reporte_pie_chart2.php?anio=${anio}&mes=${mes}&id_centro_costo=${idCentroCosto}`)
+            .then(response => response.json())
+            .then(data => {
+                if (pieChart2) pieChart2.destroy();
+
+                const labels = data.map(item => item.nombre_tipo_documento);
+                const importes = data.map(item => parseFloat(item.total_soles));
+
+                pieChart2 = new Chart(ctxPie2, {
+                    type: 'pie',
+                    data: {
+                        labels,
+                        datasets: [{
+                            data: importes,
+                            backgroundColor: labels.map(() => getRandomColor()),
+                        }]
+                    },
+                     options: {
+                        plugins: {
+                            tooltip: {
+                                callbacks: {
+                                    label: function(context) {
+                                        let label = context.label || '';
+                                        let value = context.raw || 0;
+                                        let total = context.chart.getDatasetMeta(0).total;
+                                        let percentage = ((value / total) * 100).toFixed(2);
+                                        return `${label}: S/ ${value.toFixed(2)} (${percentage}%)`;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+    }
+
+    // --- Helpers ---
+    function getRandomColor() {
+        const r = Math.floor(Math.random() * 255);
+        const g = Math.floor(Math.random() * 255);
+        const b = Math.floor(Math.random() * 255);
+        return `rgba(${r}, ${g}, ${b}, 0.7)`;
+    }
+
+    function getMonthName(monthNumber) {
+        const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+        return monthNames[monthNumber - 1];
+    }
+
+    function getMonthNumber(monthName) {
+        const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+        return monthNames.indexOf(monthName) + 1;
+    }
+
+
+    // --- Event Listeners e Inicialización ---
+    filtroAnio.addEventListener('change', actualizarGraficos);
+    filtroMes.addEventListener('change', actualizarGraficos);
+    filtroCentroCosto.addEventListener('change', actualizarGraficos);
+
+    poblarFiltroAnio();
+    poblarFiltroCentroCosto();
+    setMesActual();
+});

--- a/src/ajax/get_reporte_bar_chart.php
+++ b/src/ajax/get_reporte_bar_chart.php
@@ -1,0 +1,21 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+$anio = isset($_GET['anio']) ? (int)$_GET['anio'] : date('Y');
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_reporte_total_soles_por_mes_y_centro_costo(?)");
+    $stmt->execute([$anio]);
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode($data);
+
+} catch (Exception $e) {
+    echo json_encode([]);
+}

--- a/src/ajax/get_reporte_pie_chart1.php
+++ b/src/ajax/get_reporte_pie_chart1.php
@@ -1,0 +1,22 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+$anio = isset($_GET['anio']) ? (int)$_GET['anio'] : date('Y');
+$mes = isset($_GET['mes']) ? (int)$_GET['mes'] : date('m');
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_reporte_total_soles_por_mes_vs_centro_costo(?, ?)");
+    $stmt->execute([$anio, $mes]);
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode($data);
+
+} catch (Exception $e) {
+    echo json_encode([]);
+}

--- a/src/ajax/get_reporte_pie_chart2.php
+++ b/src/ajax/get_reporte_pie_chart2.php
@@ -1,0 +1,28 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+$anio = isset($_GET['anio']) ? (int)$_GET['anio'] : date('Y');
+$mes = isset($_GET['mes']) ? (int)$_GET['mes'] : date('m');
+$id_centro_costo = isset($_GET['id_centro_costo']) ? (int)$_GET['id_centro_costo'] : null;
+
+if ($id_centro_costo === null) {
+    echo json_encode([]);
+    exit;
+}
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_reporte_total_soles_por_tipo_documento_y_centro_costo(?, ?, ?)");
+    $stmt->execute([$anio, $mes, $id_centro_costo]);
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode($data);
+
+} catch (Exception $e) {
+    echo json_encode([]);
+}

--- a/src/ajax/get_years.php
+++ b/src/ajax/get_years.php
@@ -1,0 +1,19 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_get_years_with_documents()");
+    $stmt->execute();
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode($data);
+
+} catch (Exception $e) {
+    echo json_encode([]);
+}

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <div class="container">

--- a/src/pages/inicio.php
+++ b/src/pages/inicio.php
@@ -1,7 +1,75 @@
-<header>
-    <h1>Inicio</h1>
+<header class="mb-4">
+    <h1>Dashboard</h1>
 </header>
-<section>
-    <p>Bienvenido al Sistema de Gestión Documental.</p>
-    <p>Seleccione una opción del menú de la izquierda para comenzar.</p>
+
+<!-- Filtros -->
+<section class="card mb-4">
+    <div class="card-header">
+        Filtros
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label for="filtroAnio" class="form-label">Año</label>
+                <select id="filtroAnio" class="form-select"></select>
+            </div>
+            <div class="col-md-4">
+                <label for="filtroMes" class="form-label">Mes</label>
+                <select id="filtroMes" class="form-select">
+                    <option value="1">Enero</option>
+                    <option value="2">Febrero</option>
+                    <option value="3">Marzo</option>
+                    <option value="4">Abril</option>
+                    <option value="5">Mayo</option>
+                    <option value="6">Junio</option>
+                    <option value="7">Julio</option>
+                    <option value="8">Agosto</option>
+                    <option value="9">Septiembre</option>
+                    <option value="10">Octubre</option>
+                    <option value="11">Noviembre</option>
+                    <option value="12">Diciembre</option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="filtroCentroCosto" class="form-label">Centro de Costo</label>
+                <select id="filtroCentroCosto" class="form-select"></select>
+            </div>
+        </div>
+    </div>
 </section>
+
+<!-- Gráfico de Barras -->
+<section class="card mb-4">
+    <div class="card-header">
+        Total de Documentos en Soles por Mes y Centro de Costo
+    </div>
+    <div class="card-body">
+        <canvas id="barChart"></canvas>
+    </div>
+</section>
+
+<!-- Gráficos Circulares -->
+<section class="row">
+    <div class="col-lg-6 mb-4">
+        <div class="card h-100">
+            <div class="card-header">
+                Importes en Soles por Centro de Costo (Mes Actual)
+            </div>
+            <div class="card-body">
+                <canvas id="pieChart1"></canvas>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6 mb-4">
+        <div class="card h-100">
+            <div class="card-header">
+                Importes por Tipo de Documento (Mes y C.Costo Actual)
+            </div>
+            <div class="card-body">
+                <canvas id="pieChart2"></canvas>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script src="js/inicio_charts.js"></script>


### PR DESCRIPTION
- Adds a new dashboard to the home page (`inicio.php`) with filters for year, month, and cost center.
- Includes three new charts:
  - Bar chart for totals in soles per month, compared by cost center.
  - Pie chart for amounts in soles by cost center for a selected month.
  - Pie chart for amounts by document type for a selected month and cost center.
- Adds new stored procedures to fetch data for the charts.
- Implements AJAX endpoints and JavaScript logic to dynamically update the charts.