### PR TITLE
fix: Restore Chart.js library for dashboard

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script src="https://cdn.sheetjs.com/xlsx-latest/package/dist/xlsx.full.min.js"></script>
 </head>


### PR DESCRIPTION
- Adds the Chart.js script tag back to the main header file.
- This fixes a regression where the dashboard charts on the home page disappeared because the shared library was mistakenly removed during a previous refactoring.