### PR TITLE
fix: Restore interactivity in report builder

### DIFF
--- a/public/js/report_builder.js
+++ b/public/js/report_builder.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function () {
         moveItems(selectedColumnsEl, availableColumnsEl, selectedColumnsEl.querySelectorAll('.list-item'));
     });
 
-    document.querySelector('.dual-list-box').addEventListener('click', function(e) {
+    document.getElementById('dual-list-container').addEventListener('click', function(e) {
         if (e.target.classList.contains('list-item')) {
             e.target.classList.toggle('selected');
         }

--- a/src/pages/reportes.php
+++ b/src/pages/reportes.php
@@ -19,7 +19,7 @@
                         .list-item.selected { background-color: #dcedff; }
                         .actions-col button { margin-bottom: 10px; width: 50px; }
                     </style>
-                    <div class="row">
+                    <div class="row" id="dual-list-container">
                         <div class="col-md-5">
                             <strong>Disponibles</strong>
                             <div id="available-columns" class="list-box"></div>


### PR DESCRIPTION
- Fixes a regression where the column selection lists and the 'Generate Report' button were unresponsive.
- The issue was caused by an event listener in `report_builder.js` targeting a CSS class (`.dual-list-box`) that was removed from `reportes.php` during a layout refactoring.
- This commit adds a stable ID (`dual-list-container`) to the container element in the HTML and updates the JavaScript to use this ID as the event listener target, restoring all interactivity.