### PR TITLE
feat: Organizar archivos adjuntos en carpetas por ID de documento

### DIFF
--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -109,36 +109,45 @@ try {
 
             // -- Procesamiento de Archivos Adjuntos --
             if (isset($_FILES['adjuntos']) && is_array($_FILES['adjuntos']['name'])) {
-                $upload_dir_relative = __DIR__ . '/../../public/uploads/documentos';
-                $upload_dir_absolute = realpath($upload_dir_relative);
+                // 1. Crear directorio específico para el documento si no existe
+                $doc_upload_dir_relative = 'uploads/documentos/' . $doc_id;
+                $doc_upload_dir_absolute = realpath(__DIR__ . '/../../public') . DIRECTORY_SEPARATOR . $doc_upload_dir_relative;
 
-                if ($upload_dir_absolute === false) {
-                    throw new Exception("Error de configuración: El directorio de subida no existe en '" . htmlspecialchars($upload_dir_relative) . "'.");
-                }
-
-                if (!is_writable($upload_dir_absolute)) {
-                    throw new Exception("Error de permisos: El directorio de subida '" . htmlspecialchars($upload_dir_absolute) . "' no tiene permisos de escritura.");
+                if (!is_dir($doc_upload_dir_absolute)) {
+                    if (!mkdir($doc_upload_dir_absolute, 0775, true)) {
+                        throw new Exception("No se pudo crear el directorio para los adjuntos del documento.");
+                    }
                 }
 
                 foreach ($_FILES['adjuntos']['name'] as $key => $name) {
                     if ($_FILES['adjuntos']['error'][$key] === UPLOAD_ERR_OK) {
                         $tmp_name = $_FILES['adjuntos']['tmp_name'][$key];
-                        $file_name = basename($name);
+                        $original_file_name = basename($name);
                         $file_type = $_FILES['adjuntos']['type'][$key];
                         $file_size = $_FILES['adjuntos']['size'][$key];
 
-                        $safe_file_name = uniqid() . '-' . preg_replace("/[^a-zA-Z0-9.\-_]/", "", $file_name);
-                        $destination = $upload_dir_absolute . DIRECTORY_SEPARATOR . $safe_file_name;
+                        // 2. Sanitizar nombre de archivo y manejar colisiones
+                        $sanitized_file_name = preg_replace("/[^a-zA-Z0-9.\-_]/", "", pathinfo($original_file_name, PATHINFO_FILENAME));
+                        $extension = pathinfo($original_file_name, PATHINFO_EXTENSION);
+                        $final_file_name = $sanitized_file_name . '.' . $extension;
 
+                        $counter = 1;
+                        while (file_exists($doc_upload_dir_absolute . DIRECTORY_SEPARATOR . $final_file_name)) {
+                            $final_file_name = $sanitized_file_name . '-' . $counter . '.' . $extension;
+                            $counter++;
+                        }
+
+                        $destination = $doc_upload_dir_absolute . DIRECTORY_SEPARATOR . $final_file_name;
+
+                        // 3. Mover archivo y guardar en DB
                         if (move_uploaded_file($tmp_name, $destination)) {
                             $stmt_adjunto = $pdo->prepare("CALL sp_create_documento_adjunto(?, ?, ?, ?, ?, ?)");
-                            $storage_path = 'uploads/documentos/'; // Relative path for URLs remains the same
-                            $stmt_adjunto->execute([$doc_id, $name, $safe_file_name, $storage_path, $file_type, $file_size]);
+                            $storage_path_for_db = $doc_upload_dir_relative . '/';
+                            $stmt_adjunto->execute([$doc_id, $original_file_name, $final_file_name, $storage_path_for_db, $file_type, $file_size]);
                         } else {
-                            throw new Exception("No se pudo mover el archivo subido '" . htmlspecialchars($file_name) . "'. Verifique los permisos del servidor.");
+                            throw new Exception("No se pudo mover el archivo subido '" . htmlspecialchars($original_file_name) . "'. Verifique los permisos del servidor.");
                         }
                     } elseif ($_FILES['adjuntos']['error'][$key] !== UPLOAD_ERR_NO_FILE) {
-                        // Handle other upload errors
                         throw new Exception("Error al subir el archivo '" . htmlspecialchars($name) . "'. Código de error: " . $_FILES['adjuntos']['error'][$key]);
                     }
                 }


### PR DESCRIPTION
Refactora la lógica de almacenamiento de archivos para mejorar la organización en el servidor y la legibilidad de los nombres de archivo.

Los cambios clave son:
- Al guardar un documento con adjuntos, se crea un directorio específico para ese documento usando su ID (ej. `public/uploads/documentos/{id}/`).
- El nombre de archivo original se sanitiza para eliminar caracteres no seguros.
- Se implementa un sistema para manejar colisiones de nombres: si un archivo con el mismo nombre ya existe, se le añade un sufijo numérico (ej. `nombre-1.pdf`).
- La ruta de almacenamiento y el nombre final del archivo se guardan en la base de datos, asegurando que los enlaces de descarga y la lógica de eliminación funcionen correctamente con la nueva estructura.