### PR TITLE
fix: Establecer permisos de lectura en archivos subidos

### DIFF
--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -141,6 +141,9 @@ try {
 
                         // 3. Mover archivo y guardar en DB
                         if (move_uploaded_file($tmp_name, $destination)) {
+                            // Establecer permisos para que el archivo sea legible por el servidor web
+                            chmod($destination, 0644);
+
                             $stmt_adjunto = $pdo->prepare("CALL sp_create_documento_adjunto(?, ?, ?, ?, ?, ?)");
                             $storage_path_for_db = $doc_upload_dir_relative . '/';
                             $stmt_adjunto->execute([$doc_id, $original_file_name, $final_file_name, $storage_path_for_db, $file_type, $file_size]);


### PR DESCRIPTION
Soluciona un error `403 Forbidden` que ocurría al intentar acceder a los archivos recién subidos.

El problema era que los archivos movidos por `move_uploaded_file()` no tenían permisos de lectura para el usuario del servidor web, debido a la máscara `umask` por defecto del sistema.

La solución es añadir una llamada `chmod(\$destination, 0644);` inmediatamente después de que un archivo se sube con éxito. Esto establece explícitamente los permisos del archivo para que sea legible por todos los usuarios, lo cual es una práctica estándar y segura para archivos que deben ser servidos por un servidor web.