### PR TITLE
feat: Implementar script de descarga segura para adjuntos

### DIFF
--- a/database/20250910_add_sp_read_adjunto.sql
+++ b/database/20250910_add_sp_read_adjunto.sql
@@ -1,0 +1,23 @@
+-- =================================================================
+-- Script para añadir el SP para leer un adjunto por su ID
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_adjunto_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_adjunto_by_id`(
+    IN p_id_adjunto INT
+)
+BEGIN
+    SELECT
+        id,
+        id_documento,
+        nombre_original,
+        nombre_almacenado,
+        ruta_almacenamiento,
+        tipo_mime,
+        tamaño_bytes,
+        fecha_subida
+    FROM documento_adjuntos
+    WHERE id = p_id_adjunto;
+END$$
+DELIMITER ;

--- a/src/actions/download_attachment.php
+++ b/src/actions/download_attachment.php
@@ -1,0 +1,63 @@
+<?php
+session_start();
+require_once __DIR__ . '/../database.php';
+
+// 1. Verificación de seguridad: usuario autenticado y ID de adjunto
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    die('Acceso prohibido. Debe iniciar sesión.');
+}
+
+$id_adjunto = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id_adjunto <= 0) {
+    http_response_code(400);
+    die('Solicitud incorrecta. No se proporcionó un ID de adjunto válido.');
+}
+
+try {
+    $pdo = getDbConnection();
+
+    // 2. Obtener metadatos del archivo desde la BD
+    $stmt = $pdo->prepare("CALL sp_read_adjunto_by_id(?)");
+    $stmt->execute([$id_adjunto]);
+    $file_info = $stmt->fetch(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+
+    if (!$file_info) {
+        http_response_code(404);
+        die('Archivo no encontrado en la base de datos.');
+    }
+
+    // (Opcional) Verificación de permisos avanzada:
+    // Aquí se podría añadir una lógica para verificar si el $_SESSION['user_id']
+    // tiene permiso para ver el documento con id $file_info['id_documento'].
+
+    // 3. Construir la ruta absoluta y segura al archivo
+    $file_path = realpath(__DIR__ . '/../../public/' . $file_info['ruta_almacenamiento'] . $file_info['nombre_almacenado']);
+
+    if ($file_path === false || !file_exists($file_path)) {
+        http_response_code(404);
+        die('El archivo no existe en el servidor.');
+    }
+
+    // 4. Enviar cabeceras HTTP para la descarga/visualización
+    header('Content-Type: ' . $file_info['tipo_mime']);
+    header('Content-Disposition: inline; filename="' . basename($file_info['nombre_original']) . '"');
+    header('Content-Length: ' . filesize($file_path));
+    header('Cache-Control: private, max-age=0, must-revalidate');
+    header('Pragma: public');
+
+    // Limpiar el buffer de salida antes de enviar el archivo
+    ob_clean();
+    flush();
+
+    // 5. Enviar el contenido del archivo
+    readfile($file_path);
+    exit();
+
+} catch (Exception $e) {
+    http_response_code(500);
+    // No mostrar el mensaje de error de la excepción directamente por seguridad
+    die('Error interno del servidor al procesar la solicitud.');
+}
+?>

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -151,7 +151,7 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                             <ul class="list-group" id="lista-adjuntos">
                                 <?php foreach ($adjuntos as $adjunto): ?>
                                     <li class="list-group-item d-flex justify-content-between align-items-center" id="adjunto-<?= $adjunto['id'] ?>">
-                                        <a href="/ong/public/<?= htmlspecialchars($adjunto['ruta_almacenamiento']) . htmlspecialchars($adjunto['nombre_almacenado']) ?>" target="_blank">
+                                        <a href="../src/actions/download_attachment.php?id=<?= $adjunto['id'] ?>" target="_blank">
                                             <?= htmlspecialchars($adjunto['nombre_original']) ?>
                                         </a>
                                         <button type="button" class="btn btn-sm btn-danger" onclick="eliminarAdjunto(<?= $adjunto['id'] ?>)">Eliminar</button>


### PR DESCRIPTION
Soluciona el error `403 Forbidden` al acceder a los archivos, refactorizando el sistema para usar un script de descarga segura en lugar de enlaces directos.

Cambios:
- Se ha creado un nuevo script `src/actions/download_attachment.php`. Este script actúa como un gateway seguro: verifica la autenticación del usuario, obtiene la ruta del archivo de la base de datos y lo transmite al navegador. Esto evita problemas de permisos del servidor de archivos y mejora la seguridad.
- Se ha añadido un nuevo procedimiento almacenado `sp_read_adjunto_by_id` para que el script de descarga pueda buscar la información de un archivo de forma segura.
- Se han actualizado los enlaces en el formulario de edición de documentos (`ingreso_documentos_form.php`) para que apunten al nuevo script de descarga en lugar de a los archivos directamente.

Este enfoque es más robusto, seguro y una práctica estándar para servir archivos privados en aplicaciones web.