### PR TITLE
fix: Reducir el tamaño de los botones de acción en la grilla de docum…

### DIFF
--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -174,8 +174,8 @@ try {
                     <td><?= htmlspecialchars($doc['moneda']) ?></td>
                     <td style="text-align: right;"><?= htmlspecialchars(number_format($doc['total'], 2)) ?></td>
                     <td>
-                        <a href="index.php?page=ingreso_documentos_form&id=<?= $doc['id'] ?>" class="btn btn-edit" title="Editar"><i class="fas fa-edit"></i></a>
-                        <a href="../src/actions/documentos_process.php?action=delete&id=<?= $doc['id'] ?>" class="btn btn-delete" title="Eliminar" onclick="return confirm('¿Está seguro de que quiere eliminar este documento?');"><i class="fas fa-trash-alt"></i></a>
+                        <a href="index.php?page=ingreso_documentos_form&id=<?= $doc['id'] ?>" class="btn btn-sm btn-edit" title="Editar"><i class="fas fa-edit"></i></a>
+                        <a href="../src/actions/documentos_process.php?action=delete&id=<?= $doc['id'] ?>" class="btn btn-sm btn-delete" title="Eliminar" onclick="return confirm('¿Está seguro de que quiere eliminar este documento?');"><i class="fas fa-trash-alt"></i></a>
                     </td>
                 </tr>
                 <?php endforeach; ?>


### PR DESCRIPTION
…entos

Ajusta el tamaño de los botones de "Editar" y "Eliminar" en la tabla de `ingreso_documentos.php` para asegurar que se muestren en una sola línea y no se apilen verticalmente.

Se ha añadido la clase `btn-sm` de Bootstrap a los enlaces de acción, lo cual reduce su padding y tamaño de fuente, resultando en botones más compactos.