### PR TITLE
feat: Añadir campo de observaciones a los documentos

### DIFF
--- a/database/20250910_add_observaciones_field.sql
+++ b/database/20250910_add_observaciones_field.sql
@@ -1,0 +1,99 @@
+-- =================================================================
+-- Script para añadir el campo `observaciones` a la tabla `documentos`
+-- y actualizar los SPs correspondientes.
+-- =================================================================
+
+-- 1. Añadir la nueva columna a la tabla de documentos
+ALTER TABLE `documentos` ADD COLUMN `observaciones` TEXT NULL AFTER `glosa`;
+
+
+-- 2. Actualizar SP para leer la cabecera del documento
+DROP PROCEDURE IF EXISTS sp_read_documento_header_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_documento_header_by_id`(IN p_id INT)
+BEGIN
+    SELECT id, id_tipo_documento, id_proyecto, id_sub_proyecto, id_centro_costo, id_auxiliar, id_usuario_registro, serie_documento, numero_documento, fecha_emision, fecha_registro, moneda, tipo_cambio, subtotal, igv, total, glosa, observaciones, estado, total_soles, total_dolares
+    FROM documentos
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+
+-- 3. Actualizar SP para crear la cabecera del documento
+DROP PROCEDURE IF EXISTS sp_create_documento_header;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_documento_header`(
+    IN p_id_tipo_documento INT,
+    IN p_id_proyecto INT,
+    IN p_id_sub_proyecto INT,
+    IN p_id_centro_costo INT,
+    IN p_id_auxiliar INT,
+    IN p_id_usuario_registro INT,
+    IN p_serie_documento VARCHAR(10),
+    IN p_numero_documento VARCHAR(20),
+    IN p_fecha_emision DATE,
+    IN p_moneda ENUM('SOLES', 'DOLARES'),
+    IN p_tipo_cambio DECIMAL(10, 4),
+    IN p_subtotal DECIMAL(15, 2),
+    IN p_igv DECIMAL(15, 2),
+    IN p_total DECIMAL(15, 2),
+    IN p_total_soles DECIMAL(15, 2),
+    IN p_total_dolares DECIMAL(15, 2),
+    IN p_glosa TEXT,
+    IN p_observaciones TEXT,
+    OUT p_new_id INT
+)
+BEGIN
+    INSERT INTO documentos (id_tipo_documento, id_proyecto, id_sub_proyecto, id_centro_costo, id_auxiliar, id_usuario_registro, serie_documento, numero_documento, fecha_emision, moneda, tipo_cambio, subtotal, igv, total, total_soles, total_dolares, glosa, observaciones)
+    VALUES (p_id_tipo_documento, p_id_proyecto, p_id_sub_proyecto, p_id_centro_costo, p_id_auxiliar, p_id_usuario_registro, p_serie_documento, p_numero_documento, p_fecha_emision, p_moneda, p_tipo_cambio, p_subtotal, p_igv, p_total, p_total_soles, p_total_dolares, p_glosa, p_observaciones);
+    SET p_new_id = LAST_INSERT_ID();
+END$$
+DELIMITER ;
+
+
+-- 4. Actualizar SP para modificar la cabecera del documento
+DROP PROCEDURE IF EXISTS sp_update_documento_header;
+DELIMITER $$
+CREATE PROCEDURE `sp_update_documento_header`(
+    IN p_id INT,
+    IN p_id_tipo_documento INT,
+    IN p_id_proyecto INT,
+    IN p_id_sub_proyecto INT,
+    IN p_id_centro_costo INT,
+    IN p_id_auxiliar INT,
+    IN p_serie_documento VARCHAR(10),
+    IN p_numero_documento VARCHAR(20),
+    IN p_fecha_emision DATE,
+    IN p_moneda ENUM('SOLES', 'DOLARES'),
+    IN p_tipo_cambio DECIMAL(10, 4),
+    IN p_subtotal DECIMAL(15, 2),
+    IN p_igv DECIMAL(15, 2),
+    IN p_total DECIMAL(15, 2),
+    IN p_total_soles DECIMAL(15, 2),
+    IN p_total_dolares DECIMAL(15, 2),
+    IN p_glosa TEXT,
+    IN p_observaciones TEXT
+)
+BEGIN
+    UPDATE documentos
+    SET
+        id_tipo_documento = p_id_tipo_documento,
+        id_proyecto = p_id_proyecto,
+        id_sub_proyecto = p_id_sub_proyecto,
+        id_centro_costo = p_id_centro_costo,
+        id_auxiliar = p_id_auxiliar,
+        serie_documento = p_serie_documento,
+        numero_documento = p_numero_documento,
+        fecha_emision = p_fecha_emision,
+        moneda = p_moneda,
+        tipo_cambio = p_tipo_cambio,
+        subtotal = p_subtotal,
+        igv = p_igv,
+        total = p_total,
+        total_soles = p_total_soles,
+        total_dolares = p_total_dolares,
+        glosa = p_glosa,
+        observaciones = p_observaciones
+    WHERE id = p_id;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -82,14 +82,14 @@ try {
 
             if ($action === 'update') {
                 $doc_id = $header['id_documento'];
-                $stmt_update = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-                $stmt_update->execute([$doc_id, $header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa']]);
+                $stmt_update = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                $stmt_update->execute([$doc_id, $header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
                 $stmt_delete_details = $pdo->prepare("CALL sp_delete_documento_detalle_by_id_documento(?)");
                 $stmt_delete_details->execute([$doc_id]);
                 $response['message'] = 'Documento actualizado con éxito.';
             } else { // create
-                $stmt_create = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
-                $stmt_create->execute([$header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $_SESSION['user_id'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa']]);
+                $stmt_create = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
+                $stmt_create->execute([$header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $_SESSION['user_id'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
                 $stmt_create->closeCursor();
                 $doc_id = $pdo->query("SELECT @new_id as new_id")->fetch(PDO::FETCH_ASSOC)['new_id'];
                 if (!$doc_id) throw new Exception("No se pudo crear el encabezado del documento.");

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -145,6 +145,10 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
                         <label for="adjuntos" class="form-label">Añadir nuevos archivos</label>
                         <input type="file" class="form-control" id="adjuntos" name="adjuntos[]" multiple>
                     </div>
+                    <div class="mb-3">
+                        <label for="observaciones" class="form-label">Comentarios</label>
+                        <textarea class="form-control" id="observaciones" name="observaciones" rows="3"><?= htmlspecialchars($header['observaciones'] ?? '') ?></textarea>
+                    </div>
                     <?php if (!empty($adjuntos)): ?>
                         <div class="mb-3">
                             <p><strong>Archivos existentes:</strong></p>


### PR DESCRIPTION
- [ ] Añade un campo de texto multilínea para "Observaciones" en la cabecera del documento, permitiendo a los usuarios añadir comentarios o notas adicionales.

Cambios:
- Se añade una columna `observaciones` de tipo `TEXT` a la tabla `documentos`.
- Se crea un nuevo archivo de parche SQL para aplicar el cambio en la tabla y actualizar los procedimientos almacenados correspondientes (`sp_create_documento_header`, `sp_update_documento_header`, `sp_read_documento_header_by_id`).
- Se actualiza el script de backend `documentos_process.php` para manejar el guardado del nuevo campo.
- Se añade un `<textarea>` en el formulario de documentos (`ingreso_documentos_form.php`), ubicado dentro de la sección de "Adjuntos" como fue solicitado.