### PR TITLE
fix: Reordenar y estilizar campos en el formulario de documentos

### DIFF
--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -140,14 +140,14 @@ $centros_costo = $pdo->query("CALL sp_read_centros_costos_for_dropdown()")->fetc
 
                 <!-- Adjuntos -->
                 <fieldset class="border p-3 mb-4">
-                    <legend class="w-auto px-2 h6">Adjuntos</legend>
+                    <legend class="w-auto px-2 h6">Adjuntos y Comentarios</legend>
                     <div class="mb-3">
-                        <label for="adjuntos" class="form-label">Añadir nuevos archivos</label>
-                        <input type="file" class="form-control" id="adjuntos" name="adjuntos[]" multiple>
+                        <label for="observaciones" class="form-label"><strong>Comentarios:</strong></label>
+                        <textarea class="form-control" id="observaciones" name="observaciones" rows="3"><?= htmlspecialchars($header['observaciones'] ?? '') ?></textarea>
                     </div>
                     <div class="mb-3">
-                        <label for="observaciones" class="form-label">Comentarios</label>
-                        <textarea class="form-control" id="observaciones" name="observaciones" rows="3"><?= htmlspecialchars($header['observaciones'] ?? '') ?></textarea>
+                        <label for="adjuntos" class="form-label"><strong>Añadir nuevos archivos:</strong></label>
+                        <input type="file" class="form-control" id="adjuntos" name="adjuntos[]" multiple>
                     </div>
                     <?php if (!empty($adjuntos)): ?>
                         <div class="mb-3">


### PR DESCRIPTION
Ajusta la disposición y el estilo de los campos de "Comentarios" y "Adjuntos" en el formulario de ingreso de documentos para mejorar la usabilidad, según la solicitud del usuario.

- El campo de `textarea` para "Comentarios" ahora se muestra antes que el campo para subir archivos.
- Las etiquetas (`<label>`) para "Comentarios" y "Añadir nuevos archivos" ahora están en negrita y terminan con dos puntos para mayor claridad visual.