### PR TITLE
feat: Add template system for dynamic reports

### DIFF
--- a/database/20250913_add_report_templates_table.sql
+++ b/database/20250913_add_report_templates_table.sql
@@ -1,0 +1,9 @@
+-- Tabla para guardar plantillas de reportes dinámicos
+CREATE TABLE `reporte_plantillas` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nombre_plantilla` varchar(255) NOT NULL,
+  `columnas` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(`columnas`)),
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `nombre_plantilla` (`nombre_plantilla`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/public/js/report_builder.js
+++ b/public/js/report_builder.js
@@ -17,6 +17,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const paginationContainer = document.getElementById('paginationContainer');
     const filterTemplate = document.getElementById('filterTemplate');
 
+    // Template UI Elements
+    const templateSelect = document.getElementById('template-select');
+    const loadTemplateBtn = document.getElementById('load-template-btn');
+    const deleteTemplateBtn = document.getElementById('delete-template-btn');
+    const templateNameInput = document.getElementById('template-name-input');
+    const saveTemplateBtn = document.getElementById('save-template-btn');
+
     let reportColumns = []; // To store the dictionary columns
     let fullReportData = []; // To store the complete dataset for pagination/export
     let currentPage = 1;
@@ -309,4 +316,126 @@ document.addEventListener('DOMContentLoaded', function () {
         XLSX.utils.book_append_sheet(wb, ws, "Reporte");
         XLSX.writeFile(wb, "ReporteDinamico.xlsx", { bookSST: true });
     }
+
+    // --- Template Management ---
+
+    function loadTemplates(selectId = null) {
+        fetch('../src/ajax/plantillas_reporte_process.php?action=obtener_todas')
+            .then(response => response.json())
+            .then(result => {
+                if (!result.success) throw new Error(result.error);
+
+                templateSelect.innerHTML = '<option value="" selected>-- Seleccione una plantilla --</option>'; // Reset
+                result.templates.forEach(template => {
+                    const option = document.createElement('option');
+                    option.value = template.id;
+                    option.textContent = template.nombre_plantilla;
+                    templateSelect.appendChild(option);
+                });
+
+                if (selectId) {
+                    templateSelect.value = selectId;
+                }
+            })
+            .catch(error => {
+                console.error('Error loading templates:', error);
+                alert('No se pudieron cargar las plantillas.');
+            });
+    }
+
+    saveTemplateBtn.addEventListener('click', function() {
+        const name = templateNameInput.value.trim();
+        if (!name) {
+            alert('Por favor, ingrese un nombre para la plantilla.');
+            return;
+        }
+
+        const selectedColumns = Array.from(selectedColumnsEl.querySelectorAll('.list-item')).map(item => item.dataset.key);
+
+        fetch('../src/ajax/plantillas_reporte_process.php?action=guardar', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: name, columns: selectedColumns })
+        })
+        .then(response => response.json())
+        .then(result => {
+            if (!result.success) throw new Error(result.error);
+            alert('Plantilla guardada con éxito.');
+            templateNameInput.value = '';
+            loadTemplates(result.new_id); // Refresh list and select the new one
+        })
+        .catch(error => {
+            console.error('Error saving template:', error);
+            alert(`Error al guardar la plantilla: ${error.message}`);
+        });
+    });
+
+    loadTemplateBtn.addEventListener('click', function() {
+        const templateId = templateSelect.value;
+        if (!templateId) {
+            alert('Por favor, seleccione una plantilla para cargar.');
+            return;
+        }
+
+        fetch(`../src/ajax/plantillas_reporte_process.php?action=obtener_una&id=${templateId}`)
+            .then(response => response.json())
+            .then(result => {
+                if (!result.success) throw new Error(result.error);
+
+                // 1. Reset current selection by moving all selected columns back to available
+                const allSelectedItems = selectedColumnsEl.querySelectorAll('.list-item');
+                if (allSelectedItems.length > 0) {
+                    moveItems(selectedColumnsEl, availableColumnsEl, allSelectedItems);
+                }
+
+                // 2. Load new columns from template
+                const columnsToSelect = result.columns || [];
+
+                columnsToSelect.forEach(columnKey => {
+                    const columnElement = availableColumnsEl.querySelector(`.list-item[data-key="${columnKey}"]`);
+                    if (columnElement) {
+                        moveItems(availableColumnsEl, selectedColumnsEl, [columnElement]);
+                    }
+                });
+
+                // Also copy name to input field for easy updating
+                templateNameInput.value = templateSelect.options[templateSelect.selectedIndex].text;
+            })
+            .catch(error => {
+                console.error('Error loading template:', error);
+                alert(`Error al cargar la plantilla: ${error.message}`);
+            });
+    });
+
+    deleteTemplateBtn.addEventListener('click', function() {
+        const templateId = templateSelect.value;
+        if (!templateId) {
+            alert('Por favor, seleccione una plantilla para eliminar.');
+            return;
+        }
+
+        if (!confirm('¿Está seguro de que desea eliminar la plantilla seleccionada? Esta acción no se puede deshacer.')) {
+            return;
+        }
+
+        fetch('../src/ajax/plantillas_reporte_process.php?action=eliminar', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: templateId })
+        })
+        .then(response => response.json())
+        .then(result => {
+            if (!result.success) throw new Error(result.error);
+            alert(result.message);
+            loadTemplates(); // Refresh list
+        })
+        .catch(error => {
+            console.error('Error deleting template:', error);
+            alert(`Error al eliminar la plantilla: ${error.message}`);
+        });
+    });
+
+    // Initial load of templates
+    loadTemplates();
+
 });

--- a/src/ajax/plantillas_reporte_process.php
+++ b/src/ajax/plantillas_reporte_process.php
@@ -1,0 +1,97 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+header('Content-Type: application/json');
+require_once __DIR__ . '/../database.php';
+
+// El frontend enviará la acción como un parámetro GET, ej: /plantillas_reporte_process.php?action=obtener_todas
+$action = $_GET['action'] ?? '';
+
+try {
+    $pdo = getDbConnection();
+
+    switch ($action) {
+        // Devuelve una lista simple de todas las plantillas para poblar el dropdown
+        case 'obtener_todas':
+            $stmt = $pdo->query("SELECT id, nombre_plantilla FROM reporte_plantillas ORDER BY nombre_plantilla ASC");
+            $templates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            echo json_encode(['success' => true, 'templates' => $templates]);
+            break;
+
+        // Devuelve las columnas de una plantilla específica para cargarla en el editor
+        case 'obtener_una':
+            $id = $_GET['id'] ?? 0;
+            if (empty($id)) {
+                throw new Exception("ID de plantilla no proporcionado.");
+            }
+            $stmt = $pdo->prepare("SELECT columnas FROM reporte_plantillas WHERE id = ?");
+            $stmt->execute([$id]);
+            $template = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$template) {
+                throw new Exception("Plantilla no encontrada.");
+            }
+            // Las columnas se guardan como un string JSON, así que lo decodificamos antes de enviarlo
+            echo json_encode(['success' => true, 'columns' => json_decode($template['columnas'])]);
+            break;
+
+        // Guarda una nueva plantilla o actualiza una existente si el nombre ya existe
+        case 'guardar':
+            $input = json_decode(file_get_contents('php://input'), true);
+            $name = $input['name'] ?? '';
+            $columns = $input['columns'] ?? [];
+
+            if (empty($name) || !isset($columns)) { // Permitir guardar una plantilla vacía
+                throw new Exception("El nombre de la plantilla es obligatorio.");
+            }
+
+            $jsonColumns = json_encode($columns);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new Exception("Error interno al procesar la lista de columnas.");
+            }
+
+            // Usamos INSERT ... ON DUPLICATE KEY UPDATE para crear o actualizar.
+            // Esto funciona porque la columna 'nombre_plantilla' tiene una restricción UNIQUE.
+            $sql = "INSERT INTO reporte_plantillas (nombre_plantilla, columnas) VALUES (?, ?) ON DUPLICATE KEY UPDATE columnas = VALUES(columnas)";
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute([$name, $jsonColumns]);
+
+            // Obtenemos el ID, ya sea el nuevo insertado o el del registro actualizado.
+            $lastId = $pdo->lastInsertId();
+            if ($lastId == 0) {
+                $stmt = $pdo->prepare("SELECT id FROM reporte_plantillas WHERE nombre_plantilla = ?");
+                $stmt->execute([$name]);
+                $lastId = $stmt->fetchColumn();
+            }
+
+            echo json_encode(['success' => true, 'message' => 'Plantilla guardada correctamente.', 'new_id' => $lastId]);
+            break;
+
+        // Elimina una plantilla por su ID
+        case 'eliminar':
+            $input = json_decode(file_get_contents('php://input'), true);
+            $id = $input['id'] ?? 0;
+
+            if (empty($id)) {
+                throw new Exception("ID de plantilla no proporcionado para eliminar.");
+            }
+
+            $stmt = $pdo->prepare("DELETE FROM reporte_plantillas WHERE id = ?");
+            $stmt->execute([$id]);
+
+            if ($stmt->rowCount() > 0) {
+                echo json_encode(['success' => true, 'message' => 'Plantilla eliminada correctamente.']);
+            } else {
+                throw new Exception("No se encontró la plantilla para eliminar.");
+            }
+            break;
+
+        default:
+            throw new Exception("Acción no válida o no especificada.");
+            break;
+    }
+
+} catch (Exception $e) {
+    http_response_code(400); // Bad Request o Internal Server Error son apropiados
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}

--- a/src/pages/reportes.php
+++ b/src/pages/reportes.php
@@ -3,6 +3,54 @@
 </header>
 
 <section class="report-builder">
+    <!-- Sección de Plantillas -->
+    <div class="row">
+        <div class="col-12 mb-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="fas fa-save"></i> Plantillas de Reporte</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row align-items-end gx-2">
+                        <!-- Cargar Plantilla -->
+                        <div class="col-md-6 mb-2">
+                            <label for="template-select" class="form-label">Cargar plantilla existente</label>
+                            <select id="template-select" class="form-select">
+                                <option value="" selected>-- Seleccione una plantilla --</option>
+                            </select>
+                        </div>
+                        <div class="col-md-3 mb-2">
+                            <button id="load-template-btn" class="btn btn-secondary w-100">
+                                <i class="fas fa-download"></i> Cargar
+                            </button>
+                        </div>
+                         <div class="col-md-3 mb-2">
+                            <button id="delete-template-btn" class="btn btn-outline-danger w-100">
+                                <i class="fas fa-trash"></i> Eliminar
+                            </button>
+                        </div>
+                    </div>
+                    <hr class="my-3">
+                    <div class="row align-items-end gx-2">
+                        <!-- Guardar Plantilla -->
+                        <div class="col-md-6 mb-2">
+                            <label for="template-name-input" class="form-label">Guardar columnas seleccionadas como nueva plantilla</label>
+                            <input type="text" id="template-name-input" class="form-control" placeholder="Escriba un nombre para la plantilla...">
+                        </div>
+                        <div class="col-md-3 mb-2">
+                            <button id="save-template-btn" class="btn btn-primary w-100">
+                                <i class="fas fa-save"></i> Guardar
+                            </button>
+                        </div>
+                        <div class="col-md-3 mb-2">
+                            <small class="text-muted">Si el nombre ya existe, se actualizará.</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Fila para Selectores y Filtros -->
     <div class="row">
         <!-- Selector de Columnas -->


### PR DESCRIPTION
This feature implements a complete system for saving, loading, and deleting column configurations as named templates within the dynamic report generator.

Key changes include:
- A new `reporte_plantillas` database table to store the templates.
- A new backend API endpoint (`plantillas_reporte_process.php`) to manage CRUD operations for templates.
- A new UI section on the report generator page (`reportes.php`) with controls for saving, loading, and deleting templates.
- Frontend JavaScript logic (`report_builder.js`) to power the new UI and interact with the backend API.

This allows users to quickly recall complex column setups, significantly speeding up the process of generating frequently used reports.