### PR TITLE
style: Implement full-width layout

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -14,7 +14,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 </head>
 <body>
-    <div class="container">
+    <div class="container-fluid">
         <div class="main-wrapper">
             <aside class="sidebar">
             <div class="logo">


### PR DESCRIPTION
This commit changes the main layout of the application from a fixed-width "boxed" layout to a full-width layout that spans the entire viewport width.

The change was made by updating the main container class in `src/includes/header.php` from `container` to `container-fluid`, which is the standard Bootstrap class for a full-width container.

This addresses the user's request to make the application occupy the entire screen width.