### PR TITLE
fix: Reduce footer height by 50%

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -175,7 +175,7 @@ body.sidebar-collapsed .sidebar nav ul li a i {
 .footer {
     background-color: #ffffff;
     border-top: 1px solid #dee2e6;
-    padding: 0.5rem;
+    padding: 0.25rem 0.5rem;
     text-align: center;
     font-size: 0.9rem;
     color: #6c757d;


### PR DESCRIPTION
This commit reduces the vertical padding of the site-wide footer to make it less tall, as requested.

The `padding` property in `public/css/style.css` for the `.footer` class was changed from `0.5rem` to `0.25rem 0.5rem`.