### PR TITLE
feat: Add freeze panes and blue theme to Excel export

### DIFF
--- a/public/js/report_builder.js
+++ b/public/js/report_builder.js
@@ -278,11 +278,14 @@ document.addEventListener('DOMContentLoaded', function () {
         // Set autofilter on the sheet
         ws['!autofilter'] = { ref: ws['!ref'] };
 
-        // 2. Define styles
+        // Freeze the top row
+        ws['!views'] = [{state: 'frozen', ySplit: 1}];
+
+        // 2. Define styles with a blue color scheme
         const borderStyle = { style: 'thin', color: { rgb: "FF000000" } };
         const headerStyle = {
             font: { bold: true, color: { rgb: "FFFFFFFF" } },
-            fill: { fgColor: { rgb: "FF2C3E50" } },
+            fill: { fgColor: { rgb: "FF4F81BD" } }, // Medium Blue
             border: {
                 top: borderStyle,
                 bottom: borderStyle,
@@ -299,7 +302,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         };
         const oddRowStyle = {
-            fill: { fgColor: { rgb: "FFECF0F1" } }, // Light Grey
+            fill: { fgColor: { rgb: "FFDCE6F1" } }, // Light Blue
             border: {
                 top: borderStyle,
                 bottom: borderStyle,


### PR DESCRIPTION
This commit enhances the "Export to Excel" functionality with two improvements:
1.  The header row is now frozen, so it remains visible when scrolling through the data. This was achieved by setting the `!views` property on the worksheet object.
2.  The color scheme has been updated to use shades of blue for a more professional look, as requested. The header now has a medium blue background and the alternating rows have a light blue background.

These changes improve the usability and aesthetics of the exported reports.