### PR TITLE
fix: Correctly implement freeze panes in Excel export

### DIFF
--- a/public/js/report_builder.js
+++ b/public/js/report_builder.js
@@ -279,7 +279,7 @@ document.addEventListener('DOMContentLoaded', function () {
         ws['!autofilter'] = { ref: ws['!ref'] };
 
         // Freeze the top row
-        ws['!views'] = [{state: 'frozen', ySplit: 1}];
+        ws['!views'] = [{state: 'frozen', ySplit: 1, xSplit: 0, topLeftCell: 'A2', activePane: 'bottomLeft'}];
 
         // 2. Define styles with a blue color scheme
         const borderStyle = { style: 'thin', color: { rgb: "FF000000" } };


### PR DESCRIPTION
This commit fixes an issue where the top row in the exported Excel file was not being frozen as intended.

The previous implementation used an incomplete object for the `!views` property. This has been corrected by providing a more detailed view object, specifying the split type, coordinates, and active pane.

The `!views` property in the worksheet object is now set to: `[{state: 'frozen', ySplit: 1, xSplit: 0, topLeftCell: 'A2', activePane: 'bottomLeft'}]`

This ensures the header row remains visible when scrolling.