### PR TITLE
Add TipoERP and CodigoERP to auxiliares module

### DIFF
--- a/database/20250913_add_erp_columns_to_auxiliares.sql
+++ b/database/20250913_add_erp_columns_to_auxiliares.sql
@@ -1,0 +1,4 @@
+-- Add TipoERP and CodigoERP columns to auxiliares table
+ALTER TABLE `auxiliares`
+ADD COLUMN `TipoERP` CHAR(1) NULL,
+ADD COLUMN `CodigoERP` VARCHAR(5) NULL;

--- a/database/full_setup.sql
+++ b/database/full_setup.sql
@@ -79,13 +79,16 @@ CREATE TABLE IF NOT EXISTS `tipos_auxiliar` (
 CREATE TABLE IF NOT EXISTS `auxiliares` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
   `id_tipo_auxiliar` INT NOT NULL,
-  `tipo_doc_identidad` ENUM('RUC', 'DNI', 'CE', 'PASAPORTE', 'OTRO') NOT NULL,
-  `num_doc_identidad` VARCHAR(20) NOT NULL UNIQUE,
+  `id_tipo_documento_identidad` INT NOT NULL,
+  `num_doc_identidad` VARCHAR(20) NOT NULL,
   `razon_social_nombres` VARCHAR(255) NOT NULL,
   `direccion` VARCHAR(255),
   `telefono` VARCHAR(50),
   `email` VARCHAR(100),
+  `ubigeo` VARCHAR(6) DEFAULT NULL,
   `estado` BOOLEAN NOT NULL DEFAULT TRUE,
+  `TipoERP` CHAR(1) NULL,
+  `CodigoERP` VARCHAR(5) NULL,
   FOREIGN KEY (`id_tipo_auxiliar`) REFERENCES `tipos_auxiliar`(`id`)
 );
 
@@ -642,16 +645,19 @@ DROP PROCEDURE IF EXISTS sp_create_auxiliar;
 DELIMITER $$
 CREATE PROCEDURE `sp_create_auxiliar`(
     IN p_id_tipo_auxiliar INT,
-    IN p_tipo_doc_identidad ENUM('RUC', 'DNI', 'CE', 'PASAPORTE', 'OTRO'),
+    IN p_id_tipo_documento_identidad INT,
     IN p_num_doc_identidad VARCHAR(20),
     IN p_razon_social_nombres VARCHAR(255),
     IN p_direccion VARCHAR(255),
     IN p_telefono VARCHAR(50),
-    IN p_email VARCHAR(100)
+    IN p_email VARCHAR(100),
+    IN p_ubigeo VARCHAR(6),
+    IN p_TipoERP CHAR(1),
+    IN p_CodigoERP VARCHAR(5)
 )
 BEGIN
-    INSERT INTO auxiliares (id_tipo_auxiliar, tipo_doc_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email)
-    VALUES (p_id_tipo_auxiliar, p_tipo_doc_identidad, p_num_doc_identidad, p_razon_social_nombres, p_direccion, p_telefono, p_email);
+    INSERT INTO auxiliares (id_tipo_auxiliar, id_tipo_documento_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email, ubigeo, TipoERP, CodigoERP)
+    VALUES (p_id_tipo_auxiliar, p_id_tipo_documento_identidad, p_num_doc_identidad, p_razon_social_nombres, p_direccion, p_telefono, p_email, p_ubigeo, p_TipoERP, p_CodigoERP);
 END$$
 DELIMITER ;
 
@@ -660,7 +666,9 @@ DELIMITER $$
 CREATE PROCEDURE `sp_read_all_auxiliares`(
     IN p_nombre VARCHAR(255),
     IN p_num_doc VARCHAR(20),
-    IN p_tipo_aux INT
+    IN p_tipo_aux INT,
+    IN p_tipo_erp CHAR(1),
+    IN p_codigo_erp VARCHAR(5)
 )
 BEGIN
     SELECT a.*, ta.nombre as nombre_tipo_auxiliar
@@ -669,15 +677,16 @@ BEGIN
     WHERE
         (p_nombre IS NULL OR p_nombre = '' OR a.razon_social_nombres LIKE CONCAT('%', p_nombre, '%'))
         AND (p_num_doc IS NULL OR p_num_doc = '' OR a.num_doc_identidad LIKE CONCAT('%', p_num_doc, '%'))
-        AND (p_tipo_aux IS NULL OR p_tipo_aux = 0 OR a.id_tipo_auxiliar = p_tipo_aux);
+        AND (p_tipo_aux IS NULL OR p_tipo_aux = 0 OR a.id_tipo_auxiliar = p_tipo_aux)
+        AND (p_tipo_erp IS NULL OR p_tipo_erp = '' OR a.TipoERP LIKE CONCAT('%', p_tipo_erp, '%'))
+        AND (p_codigo_erp IS NULL OR p_codigo_erp = '' OR a.CodigoERP LIKE CONCAT('%', p_codigo_erp, '%'));
 END$$
 DELIMITER ;
 
 DROP PROCEDURE IF EXISTS sp_read_auxiliar_by_id;
-DELIMITER $$
 CREATE PROCEDURE `sp_read_auxiliar_by_id`(IN p_id INT)
 BEGIN
-    SELECT * FROM auxiliares WHERE id = p_id;
+    SELECT id, id_tipo_auxiliar, tipo_doc_identidad, num_doc_identidad, razon_social_nombres, direccion, telefono, email, estado, TipoERP, CodigoERP, id_tipo_documento_identidad, ubigeo FROM auxiliares WHERE id = p_id;
 END$$
 DELIMITER ;
 
@@ -686,25 +695,31 @@ DELIMITER $$
 CREATE PROCEDURE `sp_update_auxiliar`(
     IN p_id INT,
     IN p_id_tipo_auxiliar INT,
-    IN p_tipo_doc_identidad ENUM('RUC', 'DNI', 'CE', 'PASAPORTE', 'OTRO'),
+    IN p_id_tipo_documento_identidad INT,
     IN p_num_doc_identidad VARCHAR(20),
     IN p_razon_social_nombres VARCHAR(255),
     IN p_direccion VARCHAR(255),
     IN p_telefono VARCHAR(50),
     IN p_email VARCHAR(100),
-    IN p_estado BOOLEAN
+    IN p_ubigeo VARCHAR(6),
+    IN p_estado BOOLEAN,
+    IN p_TipoERP CHAR(1),
+    IN p_CodigoERP VARCHAR(5)
 )
 BEGIN
     UPDATE auxiliares
     SET
         id_tipo_auxiliar = p_id_tipo_auxiliar,
-        tipo_doc_identidad = p_tipo_doc_identidad,
+        id_tipo_documento_identidad = p_id_tipo_documento_identidad,
         num_doc_identidad = p_num_doc_identidad,
         razon_social_nombres = p_razon_social_nombres,
         direccion = p_direccion,
         telefono = p_telefono,
         email = p_email,
-        estado = p_estado
+        ubigeo = p_ubigeo,
+        estado = p_estado,
+        TipoERP = p_TipoERP,
+        CodigoERP = p_CodigoERP
     WHERE id = p_id;
 END$$
 DELIMITER ;

--- a/src/actions/auxiliares_process.php
+++ b/src/actions/auxiliares_process.php
@@ -34,7 +34,7 @@ try {
             }
             $stmt_check->closeCursor();
 
-            $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_create_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id_tipo_auxiliar'],
                 $_POST['id_tipo_documento_identidad'],
@@ -43,7 +43,9 @@ try {
                 $_POST['direccion'],
                 $_POST['telefono'],
                 $_POST['email'],
-                $_POST['ubigeo']
+                $_POST['ubigeo'],
+                $_POST['TipoERP'],
+                $_POST['CodigoERP']
             ]);
             $redirect_page .= '&success=' . urlencode("Auxiliar creado con éxito.");
             break;
@@ -63,7 +65,7 @@ try {
             }
             $stmt_check->closeCursor();
 
-            $stmt = $pdo->prepare("CALL sp_update_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_update_auxiliar(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id'],
                 $_POST['id_tipo_auxiliar'],
@@ -74,7 +76,9 @@ try {
                 $_POST['telefono'],
                 $_POST['email'],
                 $_POST['ubigeo'],
-                $_POST['estado']
+                $_POST['estado'],
+                $_POST['TipoERP'],
+                $_POST['CodigoERP']
             ]);
             $redirect_page .= '&success=' . urlencode("Auxiliar actualizado con éxito.");
             break;

--- a/src/pages/auxiliares.php
+++ b/src/pages/auxiliares.php
@@ -13,14 +13,16 @@ $pdo = getDbConnection();
 $filter_nombre = $_GET['nombre'] ?? null;
 $filter_num_doc = $_GET['num_doc'] ?? null;
 $filter_tipo_aux = $_GET['tipo_aux'] ?? null;
+$filter_tipo_erp = $_GET['tipo_erp'] ?? null;
+$filter_codigo_erp = $_GET['codigo_erp'] ?? null;
 
 $items = [];
 $tipos_auxiliar = [];
 
 try {
     // First query: get the main list of items
-    $stmt = $pdo->prepare("CALL sp_read_all_auxiliares(?, ?, ?)");
-    $stmt->execute([$filter_nombre, $filter_num_doc, $filter_tipo_aux]);
+    $stmt = $pdo->prepare("CALL sp_read_all_auxiliares(?, ?, ?, ?, ?)");
+    $stmt->execute([$filter_nombre, $filter_num_doc, $filter_tipo_aux, $filter_tipo_erp, $filter_codigo_erp]);
     $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
     while ($stmt->nextRowset());
     $stmt->closeCursor();
@@ -147,6 +149,14 @@ try {
             </select>
         </div>
         <div class="form-group">
+            <label for="tipo_erp">Tipo ERP</label>
+            <input type="text" id="tipo_erp" name="tipo_erp" value="<?= htmlspecialchars($filter_tipo_erp ?? '') ?>">
+        </div>
+        <div class="form-group">
+            <label for="codigo_erp">Código ERP</label>
+            <input type="text" id="codigo_erp" name="codigo_erp" value="<?= htmlspecialchars($filter_codigo_erp ?? '') ?>">
+        </div>
+        <div class="form-group">
             <button type="submit" class="btn btn-filter">Filtrar</button>
         </div>
     </form>
@@ -158,13 +168,15 @@ try {
                 <th>Tipo Doc.</th>
                 <th>Nro. Documento</th>
                 <th>Teléfono</th>
+                <th>Tipo ERP</th>
+                <th>Código ERP</th>
                 <th>Estado</th>
                 <th>Acciones</th>
             </tr>
         </thead>
         <tbody>
             <?php if (empty($items)): ?>
-                <tr><td colspan="6" style="text-align: center;">No se encontraron auxiliares.</td></tr>
+                <tr><td colspan="8" style="text-align: center;">No se encontraron auxiliares.</td></tr>
             <?php else: ?>
                 <?php foreach ($items as $item): ?>
                 <tr>
@@ -172,6 +184,8 @@ try {
                     <td><?= htmlspecialchars($item['tipo_doc_identidad']) ?></td>
                     <td><?= htmlspecialchars($item['num_doc_identidad']) ?></td>
                     <td><?= htmlspecialchars($item['telefono']) ?></td>
+                    <td><?= htmlspecialchars($item['TipoERP']) ?></td>
+                    <td><?= htmlspecialchars($item['CodigoERP']) ?></td>
                     <td><span class="badge <?= $item['estado'] ? 'bg-success' : 'bg-danger' ?>"><?= $item['estado'] ? 'Activo' : 'Inactivo' ?></span></td>
                     <td>
                         <a href="index.php?page=auxiliares_form&id=<?= $item['id'] ?>" class="btn btn-edit" title="Editar">Editar</a>

--- a/src/pages/auxiliares_form.php
+++ b/src/pages/auxiliares_form.php
@@ -146,6 +146,16 @@ try {
                 <input type="email" id="email" name="email" value="<?= htmlspecialchars($form_data['email'] ?? $item['email'] ?? '') ?>">
             </div>
         </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="TipoERP">Tipo ERP</label>
+                <input type="text" id="TipoERP" name="TipoERP" value="<?= htmlspecialchars($form_data['TipoERP'] ?? $item['TipoERP'] ?? '') ?>" maxlength="1">
+            </div>
+            <div class="form-group">
+                <label for="CodigoERP">Código ERP</label>
+                <input type="text" id="CodigoERP" name="CodigoERP" value="<?= htmlspecialchars($form_data['CodigoERP'] ?? $item['CodigoERP'] ?? '') ?>" maxlength="5">
+            </div>
+        </div>
         <?php if ($is_edit): ?>
         <div class="form-group">
             <label for="estado">Estado</label>


### PR DESCRIPTION
This commit introduces two new fields, TipoERP and CodigoERP, to the auxiliares module.

- Adds `TipoERP` (CHAR(1)) and `CodigoERP` (VARCHAR(5)) columns to the `auxiliares` table.
- Updates the `CREATE TABLE` statement in `full_setup.sql` to include the new columns and align with the application's usage of `id_tipo_documento_identidad` and `ubigeo`.
- Modifies the stored procedures (`sp_create_auxiliar`, `sp_update_auxiliar`, `sp_read_all_auxiliares`, `sp_read_auxiliar_by_id`) to support the new columns for CRUD operations and filtering.
- Updates the 'Gestion de auxiliares' page to display the new columns in the grid and add corresponding filters.
- Updates the auxiliary creation/editing form to include input fields for `TipoERP` and `CodigoERP`.
- Updates the backend processing logic to handle the new fields when creating or updating an auxiliary.