### PR TITLE
Fix: Correct column name for tipo_doc_identidad in grid view

### DIFF
--- a/database/20250914_update_auxiliares_sprocs.sql
+++ b/database/20250914_update_auxiliares_sprocs.sql
@@ -40,9 +40,22 @@ CREATE PROCEDURE `sp_read_all_auxiliares`(
     IN p_codigo_erp VARCHAR(5)
 )
 BEGIN
-    SELECT a.*, ta.nombre as nombre_tipo_auxiliar
-    FROM auxiliares a
-    JOIN tipos_auxiliar ta ON a.id_tipo_auxiliar = ta.id
+    SELECT
+        a.id,
+        a.razon_social_nombres,
+        tdi.nombre as tipo_doc_identidad,
+        a.num_doc_identidad,
+        a.telefono,
+        a.TipoERP,
+        a.CodigoERP,
+        a.estado,
+        ta.nombre as nombre_tipo_auxiliar
+    FROM
+        auxiliares a
+    JOIN
+        tipos_auxiliar ta ON a.id_tipo_auxiliar = ta.id
+    LEFT JOIN
+        tipos_documento_identidad tdi ON a.id_tipo_documento_identidad = tdi.id
     WHERE
         (p_nombre IS NULL OR p_nombre = '' OR a.razon_social_nombres LIKE CONCAT('%', p_nombre, '%'))
         AND (p_num_doc IS NULL OR p_num_doc = '' OR a.num_doc_identidad LIKE CONCAT('%', p_num_doc, '%'))

--- a/database/full_setup.sql
+++ b/database/full_setup.sql
@@ -671,9 +671,22 @@ CREATE PROCEDURE `sp_read_all_auxiliares`(
     IN p_codigo_erp VARCHAR(5)
 )
 BEGIN
-    SELECT a.*, ta.nombre as nombre_tipo_auxiliar
-    FROM auxiliares a
-    JOIN tipos_auxiliar ta ON a.id_tipo_auxiliar = ta.id
+    SELECT
+        a.id,
+        a.razon_social_nombres,
+        tdi.nombre as tipo_doc_identidad,
+        a.num_doc_identidad,
+        a.telefono,
+        a.TipoERP,
+        a.CodigoERP,
+        a.estado,
+        ta.nombre as nombre_tipo_auxiliar
+    FROM
+        auxiliares a
+    JOIN
+        tipos_auxiliar ta ON a.id_tipo_auxiliar = ta.id
+    LEFT JOIN
+        tipos_documento_identidad tdi ON a.id_tipo_documento_identidad = tdi.id
     WHERE
         (p_nombre IS NULL OR p_nombre = '' OR a.razon_social_nombres LIKE CONCAT('%', p_nombre, '%'))
         AND (p_num_doc IS NULL OR p_num_doc = '' OR a.num_doc_identidad LIKE CONCAT('%', p_num_doc, '%'))


### PR DESCRIPTION
This commit fixes a bug that caused an 'Undefined index: tipo_doc_identidad' error on the auxiliares page.

The `sp_read_all_auxiliares` stored procedure was updated to perform a `LEFT JOIN` with the `tipos_documento_identidad` table and select the document type's name, aliased as `tipo_doc_identidad`. This ensures the PHP view gets the correct data and avoids the error.

Both `full_setup.sql` and the migration script `20250914_update_auxiliares_sprocs.sql` have been updated with the corrected procedure.