### PR TITLE
feat: Implement editable combo box for Cuenta Contable

### DIFF
--- a/database/20250914_add_sp_get_cuentas_contables.sql
+++ b/database/20250914_add_sp_get_cuentas_contables.sql
@@ -1,0 +1,17 @@
+DELIMITER $$
+CREATE PROCEDURE `sp_get_cuentas_contables`(IN `p_Emp_cCodigo` CHAR(3), IN `p_Pan_cAnio` CHAR(4))
+BEGIN
+    SELECT
+        Pla_cCuentaContable AS value,
+        CONCAT(Pla_cCuentaContable, ' - ', Pla_cNombreCuenta) AS text
+    FROM
+        cnm_plan_cta
+    WHERE
+        Emp_cCodigo = p_Emp_cCodigo AND
+        Pan_cAnio = p_Pan_cAnio AND
+        Pla_cEstado = '1' AND
+        Pla_cDeleted = '0'
+    ORDER BY
+        Pla_cCuentaContable;
+END$$
+DELIMITER ;

--- a/src/ajax/get_cuentas_contables.php
+++ b/src/ajax/get_cuentas_contables.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+require_once __DIR__ . '/../database.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Acceso no autorizado']);
+    exit();
+}
+
+try {
+    $pdo = getDbConnection();
+
+    // El SP espera los parámetros de la empresa y el año
+    $empresaCodigo = defined('Emp_cCodigo') ? Emp_cCodigo : '';
+    $anio = defined('Pan_cAnio') ? Pan_cAnio : '';
+
+    $stmt = $pdo->prepare("CALL sp_get_cuentas_contables(?, ?)");
+    $stmt->execute([$empresaCodigo, $anio]);
+
+    $cuentas = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    header('Content-Type: application/json');
+    echo json_encode($cuentas);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error al obtener las cuentas contables: ' . $e->getMessage()]);
+}
+?>

--- a/src/pages/conceptos_form.php
+++ b/src/pages/conceptos_form.php
@@ -58,8 +58,10 @@ if (isset($_GET['id'])) {
             </select>
         </div>
         <div class="form-group">
-            <label for="cuenta_contable">Cuenta Contable</label>
-            <input type="text" id="cuenta_contable" name="cuenta_contable" value="<?= htmlspecialchars($item['cuenta_contable'] ?? '') ?>" maxlength="20">
+            <label for="cuenta_contable_display">Cuenta Contable</label>
+            <input type="text" id="cuenta_contable_display" name="cuenta_contable_display" list="cuentas_contables_list" value="" maxlength="150" autocomplete="off" placeholder="Escriba para buscar...">
+            <input type="hidden" id="cuenta_contable" name="cuenta_contable" value="<?= htmlspecialchars($item['cuenta_contable'] ?? '') ?>">
+            <datalist id="cuentas_contables_list"></datalist>
         </div>
         <div class="form-group">
             <label for="descripcion">Descripción</label>
@@ -78,3 +80,57 @@ if (isset($_GET['id'])) {
         <button type="submit" class="btn-submit"><?= $is_edit ? 'Actualizar' : 'Crear' ?> Concepto</button>
     </form>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const displayInput = document.getElementById('cuenta_contable_display');
+    const hiddenInput = document.getElementById('cuenta_contable');
+    const dataList = document.getElementById('cuentas_contables_list');
+    let accountsData = [];
+
+    function setInitialValue() {
+        const initialCode = hiddenInput.value;
+        if (initialCode && accountsData.length > 0) {
+            const account = accountsData.find(acc => acc.value === initialCode);
+            if (account) {
+                displayInput.value = account.text;
+            }
+        }
+    }
+
+    fetch('../src/ajax/get_cuentas_contables.php')
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                console.error('Error del servidor:', data.error);
+                return;
+            }
+            accountsData = data;
+            data.forEach(cuenta => {
+                const option = document.createElement('option');
+                option.value = cuenta.text;
+                option.dataset.value = cuenta.value;
+                dataList.appendChild(option);
+            });
+
+            // Si estamos editando, intentamos poner el valor descriptivo
+            setInitialValue();
+        })
+        .catch(error => {
+            console.error('Error al cargar las cuentas contables:', error);
+        });
+
+    displayInput.addEventListener('input', function(e) {
+        const inputText = e.target.value;
+        const selectedOption = Array.from(dataList.options).find(opt => opt.value === inputText);
+
+        if (selectedOption) {
+            hiddenInput.value = selectedOption.dataset.value;
+        } else {
+            // Si el usuario borra el input o escribe algo que no está en la lista,
+            // borramos el valor del campo oculto para evitar enviar un dato inválido.
+            hiddenInput.value = '';
+        }
+    });
+});
+</script>


### PR DESCRIPTION
Replaces the 'Cuenta Contable' text field in the 'Conceptos' form with a searchable, editable combo box.

- Adds a new stored procedure `sp_get_cuentas_contables` to fetch accounting accounts from the `cnm_plan_cta` table.
- Creates a new AJAX endpoint to provide the data to the frontend.
- Modifies the concept form to use an `<input>` with a `<datalist>` for the combo box functionality.
- Implements JavaScript to fetch data, populate the list, and ensure the correct account code is submitted via a hidden input field.