### PR TITLE
fix: Update sp_get_cuentas_contables logic

### DIFF
--- a/database/20250914_add_sp_get_cuentas_contables.sql
+++ b/database/20250914_add_sp_get_cuentas_contables.sql
@@ -9,8 +9,7 @@ BEGIN
     WHERE
         Emp_cCodigo = p_Emp_cCodigo AND
         Pan_cAnio = p_Pan_cAnio AND
-        Pla_cEstado = '1' AND
-        Pla_cDeleted = '0'
+        Pla_cEstado = 'A'  AND Pla_cTitulo='N'
     ORDER BY
         Pla_cCuentaContable;
 END$$


### PR DESCRIPTION
Updates the WHERE clause in the `sp_get_cuentas_contables` stored procedure to correctly filter for active and non-header accounts (`Pla_cEstado = 'A' AND Pla_cTitulo='N'`).

This change is based on user feedback to ensure the correct set of accounting accounts is returned.