### PR TITLE
Implement role-based access control for the user management pages.

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -63,6 +63,7 @@
                     </li>
                     
                     
+                    <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'administrador'): ?>
                     <li>
                         <a href="#seguridadSubmenu" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
                             <div><i class="fas fa-users"></i><span class="sidebar-item-text"> Seguridad</span></div>
@@ -72,6 +73,7 @@
                             <li><a href="index.php?page=usuarios"><span class="sidebar-item-text">Usuarios</span></a></li>
                         </ul>
                     </li>
+                    <?php endif; ?>
 
                     <hr>
                     <li><a href="index.php?page=perfil"><i class="fas fa-user-circle"></i><span class="sidebar-item-text"> Mi Perfil</span></a></li>

--- a/src/pages/usuarios.php
+++ b/src/pages/usuarios.php
@@ -2,8 +2,9 @@
 require_once __DIR__ . '/../database.php';
 
 // Solo los administradores pueden ver esta página
-if ($_SESSION['user_role'] !== 'administrador') {
-    echo "<p>Acceso denegado.</p>";
+if (!isset($_SESSION['user_role']) || $_SESSION['user_role'] !== 'administrador') {
+    // Redirigir a la página de inicio con un mensaje de error
+    header('Location: index.php?page=inicio&error=acceso_denegado');
     exit();
 }
 

--- a/src/pages/usuarios_form.php
+++ b/src/pages/usuarios_form.php
@@ -2,8 +2,9 @@
 require_once __DIR__ . '/../database.php';
 
 // Solo los administradores pueden acceder
-if ($_SESSION['user_role'] !== 'administrador') {
-    echo "<p>Acceso denegado.</p>";
+if (!isset($_SESSION['user_role']) || $_SESSION['user_role'] !== 'administrador') {
+    // Redirigir a la página de inicio con un mensaje de error
+    header('Location: index.php?page=inicio&error=acceso_denegado');
     exit();
 }
 


### PR DESCRIPTION
- The "Usuarios" menu item is now only visible to users with the 'administrador' role.
- Added server-side checks to `usuarios.php` and `usuarios_form.php` to prevent direct URL access by non-administrators. Unauthorized users are redirected to the homepage.
- This ensures that only administrators can view, create, edit, or delete user records.