### PR TITLE
fix: Correct CSS to prevent submenu collapse

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -100,7 +100,7 @@ body.sidebar-collapsed .sidebar nav ul li a i {
     align-items: center;
 }
 
-.sidebar nav ul li .collapse {
+.sidebar nav ul li .collapse:not(.show) {
     display: none; /* Oculto por defecto */
 }
 


### PR DESCRIPTION
This commit addresses the final root cause of the menu collapsing issue. The server-side logic to keep the menu open was functioning correctly, but a CSS rule in `style.css` was unconditionally hiding the submenus, overriding Bootstrap's `.show` class due to higher specificity.

The CSS selector has been changed from:
`.sidebar nav ul li .collapse`
to:
`.sidebar nav ul li .collapse:not(.show)`

This ensures that the custom style only hides the submenu when the `.show` class is not present, allowing the server-side logic to correctly display the active submenu on page load. This resolves the visual bug and provides the intended user experience.