### PR TITLE
feat: Add "Migrar TC" button with custom response handling

### DIFF
--- a/src/pages/tipos_cambio.php
+++ b/src/pages/tipos_cambio.php
@@ -188,12 +188,22 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         })
         .then(data => {
-            alert(data.message || 'Migración completada con éxito.');
-            location.reload(); // Reload the page to show new data
+            if (data.status === 'success') {
+                if (data.data && data.data.inserted > 0) {
+                    showAlertModal(`Se insertaron ${data.data.inserted} registros.`);
+                } else {
+                    showAlertModal('No se encontraron registros a migrar.');
+                }
+                // Reload after a short delay to allow the user to read the modal
+                setTimeout(() => location.reload(), 2000);
+            } else {
+                // Handle cases where status is not 'success'
+                throw new Error(data.message || 'La migración falló pero el servidor no especificó un error.');
+            }
         })
         .catch(error => {
             console.error('Error en la migración:', error);
-            alert(`Ocurrió un error durante la migración: ${error.message}`);
+            showAlertModal(`Ocurrió un error durante la migración: ${error.message}`);
         })
         .finally(() => {
             // Re-enable button


### PR DESCRIPTION
This commit adds a new "Migrar TC" (Migrate Exchange Rate) button to the "Mantenimiento de Tipos de Cambio" page and implements custom logic for handling the API response.

- A new button is added to the UI to trigger the migration process.
- A JavaScript event listener makes a POST request to the configured Node-RED API endpoint, passing the selected year and month.
- The `fetch` call's response handling is updated to use the project's global `showAlertModal` function instead of a standard `alert`.
- It displays specific success or error messages based on the `status` and `data.inserted` fields in the API response, as requested.
- A `setTimeout` is used before reloading the page on success to ensure the user has time to read the notification modal.