### PR TITLE
feat: Enhance Cost Centers with Year field and Migration button

### DIFF
--- a/src/pages/centros_costos.php
+++ b/src/pages/centros_costos.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../database.php';
+require_once __DIR__ . '/../../config/config.php';
 
 
 // Obtener los valores del filtro
@@ -37,7 +38,10 @@ try {
     <h1>Mantenimiento de Centros de Costos</h1>
 </header>
 <section>
-    <a href="index.php?page=centros_costos_form" class="btn btn-add">Añadir Nuevo Centro de Costo</a>
+    <div class="action-buttons" style="display: flex; gap: 10px; margin-bottom: 20px;">
+        <a href="index.php?page=centros_costos_form" class="btn btn-add" style="display: inline-block;">Añadir Nuevo Centro de Costo</a>
+        <button id="btnMigrarCc" class="btn btn-primary" style="background-color: #007bff; border: none; cursor: pointer; color: white; padding: 5px 10px; border-radius: 4px;">Migrar CC</button>
+    </div>
 
     <form action="index.php" method="GET" class="filter-form">
         <input type="hidden" name="page" value="centros_costos">
@@ -91,3 +95,59 @@ try {
         </tbody>
     </table>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const nodeRedUrl = '<?php echo NODE_RED; ?>';
+    const yearSelect = document.getElementById('year');
+    const migrarCcBtn = document.getElementById('btnMigrarCc');
+
+    migrarCcBtn.addEventListener('click', function() {
+        const year = yearSelect.value;
+
+        if (!year || year === '0') {
+            showAlertModal('Por favor, seleccione un año específico para la migración.');
+            return;
+        }
+
+        const requestBody = {
+            "Emp_cCodigo": "088",
+            "Pan_cAnio": year
+        };
+
+        migrarCcBtn.disabled = true;
+        migrarCcBtn.textContent = 'Migrando...';
+
+        fetch(`${nodeRedUrl}/maestros/migraracc`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody)
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Error del servidor: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.status === 'success') {
+                if (data.data && data.data.inserted > 0) {
+                    showAlertModal(`Se insertaron ${data.data.inserted} registros.`);
+                } else {
+                    showAlertModal('No se encontraron registros a migrar.');
+                }
+                setTimeout(() => location.reload(), 2000);
+            } else {
+                throw new Error(data.message || 'La migración falló.');
+            }
+        })
+        .catch(error => {
+            showAlertModal(`Ocurrió un error: ${error.message}`);
+        })
+        .finally(() => {
+            migrarCcBtn.disabled = false;
+            migrarCcBtn.textContent = 'Migrar CC';
+        });
+    });
+});
+</script>


### PR DESCRIPTION
This commit introduces a comprehensive set of features to the Cost Centers maintenance module, allowing for year-specific management and data migration.

Key changes include:
1.  **Database Schema:**
    - The `centros_costos` table is altered to include a new `anio` column.
    - Stored procedures (`read_all`, `read_by_id`, `create`, `update`) are updated to support the new `anio` field for filtering and CRUD operations.

2.  **UI and Backend (List View):**
    - A new 'Año' dropdown filter is added to the main list view.
    - The results grid now displays the 'Año' for each record.
    - A "Migrar CC" button is added, which triggers an API call to a Node-RED service, passing the selected year.

3.  **UI and Backend (Form View):**
    - The create/edit form now includes an 'Año' dropdown to save the year for a cost center.
    - A 'Cancelar' button has been added for better navigation.

4.  **Client-Side Logic:**
    - JavaScript is added to handle the "Migrar CC" button click, perform the API call, and provide user feedback via a modal dialog.