### PR TITLE
feat: Enhance Cost Centers with Year, Migration Button, and UI Fixes

### DIFF
--- a/src/pages/centros_costos.php
+++ b/src/pages/centros_costos.php
@@ -40,7 +40,7 @@ try {
 <section>
     <div class="action-buttons" style="display: flex; gap: 10px; margin-bottom: 20px;">
         <a href="index.php?page=centros_costos_form" class="btn btn-add" style="display: inline-block;">Añadir Nuevo Centro de Costo</a>
-        <button id="btnMigrarCc" class="btn btn-primary" style="background-color: #007bff; border: none; cursor: pointer; color: white; padding: 5px 10px; border-radius: 4px;">Migrar CC</button>
+        <a href="#" id="btnMigrarCc" class="btn btn-primary" role="button" style="background-color: #007bff; text-decoration: none;">Migrar CC</a>
     </div>
 
     <form action="index.php" method="GET" class="filter-form">
@@ -102,7 +102,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const yearSelect = document.getElementById('year');
     const migrarCcBtn = document.getElementById('btnMigrarCc');
 
-    migrarCcBtn.addEventListener('click', function() {
+    migrarCcBtn.addEventListener('click', function(event) {
+        event.preventDefault(); // Prevent the link from navigating
         const year = yearSelect.value;
 
         if (!year || year === '0') {


### PR DESCRIPTION
This commit introduces a comprehensive set of features and improvements to the Cost Centers maintenance module, allowing for year-specific management and data migration.

Key changes include:
1.  **Database Schema & Logic:**
    - The `centros_costos` table is altered to include a new `anio` column.
    - Stored procedures (`read_all`, `read_by_id`, `create`, `update`) are updated to support the new `anio` field for filtering and CRUD operations.

2.  **UI and Backend (List View):**
    - A new 'Año' dropdown filter is added.
    - The results grid now displays the 'Año' for each record.
    - A "Migrar CC" button is added, which triggers an API call to a Node-RED service, passing the selected year.

3.  **UI and Backend (Form View):**
    - The create/edit form now includes an 'Año' dropdown to save the year.
    - A 'Cancelar' button has been added for better navigation.

4.  **Client-Side Logic & UI Fixes:**
    - JavaScript is added to handle the "Migrar CC" button click, perform the API call, and provide custom user feedback via a modal dialog.
    - The "Migrar CC" `<button>` is converted to an `<a>` tag to ensure its height is consistent with the adjacent 'Añadir' button, fixing a styling issue.