### PR TITLE
feat: Añadir campo año a Mantenimiento de Conceptos

### DIFF
--- a/database/20250914_add_anio_to_conceptos.sql
+++ b/database/20250914_add_anio_to_conceptos.sql
@@ -1,0 +1,126 @@
+-- =================================================================
+-- FECHA: 2025-09-14
+-- AUTOR: Jules AI
+-- DESCRIPCIÓN: Añade el campo `año` a la tabla `conceptos` y actualiza
+-- los procedimientos almacenados relacionados.
+-- =================================================================
+
+-- 1. Añadir la columna `año` a la tabla `conceptos`
+-- =================================================================
+DELIMITER $$
+CREATE PROCEDURE `patch_add_anio_to_conceptos`()
+BEGIN
+    IF NOT EXISTS (SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'conceptos' AND COLUMN_NAME = 'año') THEN
+        ALTER TABLE `conceptos` ADD COLUMN `año` INT(4) NULL AFTER `tipo`;
+    END IF;
+END$$
+DELIMITER ;
+CALL patch_add_anio_to_conceptos();
+DROP PROCEDURE patch_add_anio_to_conceptos;
+
+
+-- 2. Actualizar procedimientos almacenados de `conceptos`
+-- =================================================================
+
+-- sp_create_concepto
+DROP PROCEDURE IF EXISTS sp_create_concepto;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_concepto`(
+    IN p_codigo VARCHAR(20),
+    IN p_nombre VARCHAR(255),
+    IN p_descripcion TEXT,
+    IN p_tipo ENUM('INGRESO', 'GASTO'),
+    IN p_año INT,
+    IN p_cuenta_contable VARCHAR(20)
+)
+BEGIN
+    INSERT INTO conceptos (codigo, nombre, descripcion, tipo, año, cuenta_contable)
+    VALUES (p_codigo, p_nombre, p_descripcion, p_tipo, p_año, p_cuenta_contable);
+END$$
+DELIMITER ;
+
+-- sp_update_concepto
+DROP PROCEDURE IF EXISTS sp_update_concepto;
+DELIMITER $$
+CREATE PROCEDURE `sp_update_concepto`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(255),
+    IN p_descripcion TEXT,
+    IN p_tipo ENUM('INGRESO', 'GASTO'),
+    IN p_año INT,
+    IN p_estado BOOLEAN,
+    IN p_cuenta_contable VARCHAR(20)
+)
+BEGIN
+    UPDATE conceptos
+    SET
+        nombre = p_nombre,
+        descripcion = p_descripcion,
+        tipo = p_tipo,
+        año = p_año,
+        estado = p_estado,
+        cuenta_contable = p_cuenta_contable
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- sp_read_all_conceptos
+DROP PROCEDURE IF EXISTS sp_read_all_conceptos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_conceptos`(
+    IN p_año INT,
+    IN p_codigo VARCHAR(20),
+    IN p_nombre VARCHAR(255),
+    IN p_tipo VARCHAR(10)
+)
+BEGIN
+    SELECT
+        id,
+        codigo,
+        nombre,
+        descripcion,
+        tipo,
+        año,
+        cuenta_contable,
+        estado
+    FROM conceptos
+    WHERE
+        (p_año IS NULL OR p_año = '' OR año = p_año)
+        AND (p_codigo IS NULL OR p_codigo = '' OR codigo LIKE CONCAT('%', p_codigo, '%'))
+        AND (p_nombre IS NULL OR p_nombre = '' OR nombre LIKE CONCAT('%', p_nombre, '%'))
+        AND (p_tipo IS NULL OR p_tipo = '' OR tipo = p_tipo);
+END$$
+DELIMITER ;
+
+-- sp_read_concepto_by_id
+DROP PROCEDURE IF EXISTS sp_read_concepto_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_concepto_by_id`(IN p_id INT)
+BEGIN
+    SELECT
+        id,
+        codigo,
+        nombre,
+        descripcion,
+        tipo,
+        año,
+        estado,
+        cuenta_contable
+    FROM conceptos
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+
+-- 3. Crear procedimiento para obtener los años de los conceptos
+-- =================================================================
+DROP PROCEDURE IF EXISTS sp_get_conceptos_years;
+DELIMITER $$
+CREATE PROCEDURE `sp_get_conceptos_years`()
+BEGIN
+    SELECT DISTINCT año
+    FROM conceptos
+    WHERE año IS NOT NULL
+    ORDER BY año DESC;
+END$$
+DELIMITER ;

--- a/src/actions/conceptos_process.php
+++ b/src/actions/conceptos_process.php
@@ -13,23 +13,25 @@ $pdo = getDbConnection();
 try {
     switch ($action) {
         case 'create':
-            $stmt = $pdo->prepare("CALL sp_create_concepto(?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_create_concepto(?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['codigo'],
                 $_POST['nombre'],
                 $_POST['descripcion'],
                 $_POST['tipo'],
+                $_POST['año'],
                 $_POST['cuenta_contable']
             ]);
             break;
 
         case 'update':
-            $stmt = $pdo->prepare("CALL sp_update_concepto(?, ?, ?, ?, ?, ?)");
+            $stmt = $pdo->prepare("CALL sp_update_concepto(?, ?, ?, ?, ?, ?, ?)");
             $stmt->execute([
                 $_POST['id'],
                 $_POST['nombre'],
                 $_POST['descripcion'],
                 $_POST['tipo'],
+                $_POST['año'],
                 $_POST['estado'],
                 $_POST['cuenta_contable']
             ]);

--- a/src/ajax/get_conceptos_years.php
+++ b/src/ajax/get_conceptos_years.php
@@ -1,0 +1,21 @@
+<?php
+error_reporting(0);
+ini_set('display_errors', 0);
+
+require_once __DIR__ . '/../database.php';
+
+header('Content-Type: application/json');
+
+try {
+    $pdo = getDbConnection();
+    $stmt = $pdo->prepare("CALL sp_get_conceptos_years()");
+    $stmt->execute();
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode($data);
+
+} catch (Exception $e) {
+    // Devolver un array vacío en caso de error
+    echo json_encode([]);
+}
+?>

--- a/src/pages/conceptos.php
+++ b/src/pages/conceptos.php
@@ -3,14 +3,15 @@ require_once __DIR__ . '/../database.php';
 
 
 // Obtener los valores del filtro
+$filter_año = $_GET['año'] ?? null;
 $filter_codigo = $_GET['codigo'] ?? null;
 $filter_nombre = $_GET['nombre'] ?? null;
 $filter_tipo = $_GET['tipo'] ?? null;
 
 try {
     $pdo = getDbConnection();
-    $stmt = $pdo->prepare("CALL sp_read_all_conceptos(?, ?, ?)");
-    $stmt->execute([$filter_codigo, $filter_nombre, $filter_tipo]);
+    $stmt = $pdo->prepare("CALL sp_read_all_conceptos(?, ?, ?, ?)");
+    $stmt->execute([$filter_año, $filter_codigo, $filter_nombre, $filter_tipo]);
     $items = $stmt->fetchAll();
 } catch (PDOException $e) {
     die("Error al obtener los conceptos: " . $e->getMessage());
@@ -42,6 +43,13 @@ try {
     <form action="index.php" method="GET" class="filter-form">
         <input type="hidden" name="page" value="conceptos">
         <div class="form-group">
+            <label for="año">Año</label>
+            <select id="año" name="año">
+                <option value="">Todos</option>
+                <!-- Opciones de año se cargarán aquí -->
+            </select>
+        </div>
+        <div class="form-group">
             <label for="codigo">Código</label>
             <input type="text" id="codigo" name="codigo" value="<?= htmlspecialchars($filter_codigo ?? '') ?>">
         </div>
@@ -68,6 +76,7 @@ try {
                 <th>Nombre</th>
                 <th>Tipo</th>
                 <th>Descripción</th>
+                <th>Año</th>
                 <th>Cta. Contable</th>
                 <th>Estado</th>
                 <th>Acciones</th>
@@ -81,6 +90,7 @@ try {
                 <td><?= htmlspecialchars($item['nombre']) ?></td>
                 <td><?= htmlspecialchars($item['tipo']) ?></td>
                 <td><?= htmlspecialchars($item['descripcion']) ?></td>
+                <td><?= htmlspecialchars($item['año']) ?></td>
                 <td><?= htmlspecialchars($item['cuenta_contable']) ?></td>
                 <td><?= $item['estado'] ? 'Activo' : 'Inactivo' ?></td>
                 <td>
@@ -92,3 +102,31 @@ try {
         </tbody>
     </table>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const anioSelect = document.getElementById('año');
+    const selectedAnio = "<?= htmlspecialchars($filter_año ?? '') ?>";
+
+    fetch('../src/ajax/get_conceptos_years.php')
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                console.error('Error del servidor:', data.error);
+                return;
+            }
+            data.forEach(item => {
+                const option = document.createElement('option');
+                option.value = item.año;
+                option.textContent = item.año;
+                if (item.año == selectedAnio) {
+                    option.selected = true;
+                }
+                anioSelect.appendChild(option);
+            });
+        })
+        .catch(error => {
+            console.error('Error al cargar los años:', error);
+        });
+});
+</script>

--- a/src/pages/conceptos_form.php
+++ b/src/pages/conceptos_form.php
@@ -56,6 +56,12 @@ if (isset($_GET['id'])) {
             </select>
         </div>
         <div class="form-group">
+            <label for="año">Año</label>
+            <select id="año" name="año" required>
+                <!-- Opciones de año se cargarán aquí -->
+            </select>
+        </div>
+        <div class="form-group">
             <label for="cuenta_contable_display">Cuenta Contable</label>
             <input type="text" id="cuenta_contable_display" name="cuenta_contable_display" list="cuentas_contables_list" value="" maxlength="150" autocomplete="off" placeholder="Escriba para buscar...">
             <input type="hidden" id="cuenta_contable" name="cuenta_contable" value="<?= htmlspecialchars($item['cuenta_contable'] ?? '') ?>">
@@ -133,5 +139,60 @@ document.addEventListener('DOMContentLoaded', function() {
             hiddenInput.value = '';
         }
     });
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+    const anioSelect = document.getElementById('año');
+    const currentAnio = "<?= htmlspecialchars($item['año'] ?? '') ?>";
+
+    // Si no hay años, podemos agregar el actual o dejarlo vacío
+    // Para este caso, vamos a buscar los años disponibles
+    fetch('../src/ajax/get_conceptos_years.php')
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                console.error('Error del servidor:', data.error);
+                return;
+            }
+
+            // Si no hay años en la BD, se puede agregar el año actual como opción
+            let years = data.map(item => item.año);
+            if (years.length === 0) {
+                const currentServerYear = new Date().getFullYear();
+                years.push(currentServerYear);
+            }
+
+            // Si estamos editando y el año del item no está en la lista, lo agregamos
+            if (currentAnio && !years.includes(parseInt(currentAnio))) {
+                years.push(parseInt(currentAnio));
+                years.sort((a, b) => b - a); // Re-ordenar descendente
+            }
+
+            anioSelect.innerHTML = ''; // Limpiar opciones existentes
+            years.forEach(year => {
+                const option = document.createElement('option');
+                option.value = year;
+                option.textContent = year;
+                if (year == currentAnio) {
+                    option.selected = true;
+                }
+                anioSelect.appendChild(option);
+            });
+
+            // Si no hay año seleccionado (ej. en 'crear'), y hay años, seleccionar el más reciente
+            if (!currentAnio && years.length > 0) {
+                 anioSelect.value = years[0];
+            }
+        })
+        .catch(error => {
+            console.error('Error al cargar los años:', error);
+            // Fallback: agregar solo el año actual si la carga falla
+            const option = document.createElement('option');
+            const year = new Date().getFullYear();
+            option.value = year;
+            option.textContent = year;
+            anioSelect.appendChild(option);
+            anioSelect.value = year;
+        });
 });
 </script>


### PR DESCRIPTION
Se ha añadido el campo "año" a la funcionalidad de "Mantenimiento de Conceptos", tal como se solicitó.

Los cambios incluyen:
- Un nuevo script SQL (`database/20250914_add_anio_to_conceptos.sql`) que:
  - Añade la columna `año` a la tabla `conceptos`.
  - Actualiza los procedimientos almacenados (`sp_create_concepto`, `sp_update_concepto`, `sp_read_all_conceptos`, `sp_read_concepto_by_id`) para manejar el nuevo campo.
  - Crea un nuevo procedimiento `sp_get_conceptos_years` para obtener los años distintos.
- Un nuevo endpoint AJAX (`src/ajax/get_conceptos_years.php`) para poblar los desplegables de año.
- Actualizaciones en el frontend:
  - `src/pages/conceptos.php`: Se ha añadido un filtro de "Año" y una columna "Año" en la grilla.
  - `src/pages/conceptos_form.php`: Se ha añadido un campo de selección de "Año" en el formulario de creación/edición.
- Actualización del backend (`src/actions/conceptos_process.php`) para pasar el valor del año a los procedimientos almacenados correspondientes.