### PR TITLE
fix: Actualizar en tiempo real la búsqueda de cuentas por año

### DIFF
--- a/src/pages/conceptos_form.php
+++ b/src/pages/conceptos_form.php
@@ -137,7 +137,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // --- Event Listeners ---
 
     // Cuando el valor del año cambia, limpia el campo de cuenta y recarga las cuentas.
-    anioInput.addEventListener('change', function() {
+    anioInput.addEventListener('input', function() {
         cuentaDisplayInput.value = '';
         cuentaHiddenInput.value = '';
         loadCuentasContables(this.value);


### PR DESCRIPTION
Se ha mejorado la experiencia de usuario en el formulario de conceptos. La lista de 'Cuentas Contables' ahora se actualiza en tiempo real a medida que el usuario escribe en el campo 'Año'.

El cambio consiste en modificar el event listener de JavaScript del evento `change` al evento `input` para el campo 'Año'.