### PR TITLE
fix: Corregir filtrado por año para Centros de Costo

### DIFF
--- a/database/20250915_fix_sp_read_centros_costos_dropdown.sql
+++ b/database/20250915_fix_sp_read_centros_costos_dropdown.sql
@@ -1,0 +1,17 @@
+-- =================================================================
+-- FECHA: 2025-09-15
+-- AUTOR: Jules AI
+-- DESCRIPCIÓN: Corrige el SP sp_read_centros_costos_for_dropdown
+-- para que use la columna correcta `anio` en lugar de `año`.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_centros_costos_for_dropdown;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_centros_costos_for_dropdown`(IN p_anio INT)
+BEGIN
+    SELECT id, nombre
+    FROM centros_costos
+    WHERE estado = TRUE AND (anio = p_anio OR anio IS NULL)
+    ORDER BY nombre ASC;
+END$$
+DELIMITER ;


### PR DESCRIPTION
Este commit corrige un bug crítico en el formulario de 'Nuevo/Editar Documento' donde el menú desplegable de 'Centro de Costo' no se filtraba correctamente por año.

El problema se debía a una inconsistencia en el nombre de la columna de año entre las tablas `conceptos` (`año`) y `centros_costos` (`anio`).

La corrección implica:
- Un nuevo script SQL (`database/20250915_fix_sp_read_centros_costos_dropdown.sql`) que actualiza el procedimiento almacenado `sp_read_centros_costos_for_dropdown` para que use el nombre de columna correcto (`anio`).