### PR TITLE
Fix: Change button hover color to gray

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -145,3 +145,8 @@ body.sidebar-collapsed .sidebar nav ul li a i {
     font-size: 0.9rem;
     color: #6c757d;
 }
+
+.btn:hover, .btn-primary:hover, .btn-secondary:hover, .btn-success:hover, .btn-danger:hover, .btn-warning:hover, .btn-info:hover, .btn-light:hover, .btn-dark:hover {
+    background-color: #e9ecef;
+    border-color: #e9ecef;
+}


### PR DESCRIPTION
The default Bootstrap button hover behavior was to make the background transparent. This made the buttons disappear when hovered over.

This change adds a CSS rule to override the default Bootstrap styles and set the background color of all buttons to a light gray (#e9ecef) on hover. This applies to all button types and ensures a consistent look and feel across the application.