### PR TITLE
Fix: Change button hover color to a darker gray

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -147,6 +147,6 @@ body.sidebar-collapsed .sidebar nav ul li a i {
 }
 
 .btn:hover, .btn-primary:hover, .btn-secondary:hover, .btn-success:hover, .btn-danger:hover, .btn-warning:hover, .btn-info:hover, .btn-light:hover, .btn-dark:hover {
-    background-color: #e9ecef;
-    border-color: #e9ecef;
+    background-color: #cccccc;
+    border-color: #cccccc;
 }


### PR DESCRIPTION
The user requested a darker gray for the button hover effect. This commit updates the CSS to use `#cccccc` instead of `#e9ecef`.

This change adds a CSS rule to override the default Bootstrap styles and set the background color of all buttons to a darker gray (#cccccc) on hover. This applies to all button types and ensures a consistent look and feel across the application.