### PR TITLE
feat: Implement cost center distribution per detail line

### DIFF
--- a/database/20250920_add_cost_center_distribution.sql
+++ b/database/20250920_add_cost_center_distribution.sql
@@ -1,0 +1,181 @@
+-- =================================================================
+-- PARCHE PARA DISTRIBUCIÓN DE CENTROS DE COSTO
+-- Fecha: 2025-09-20
+-- Autor: Jules AI
+-- Descripción: Modifica la estructura de la base de datos para permitir
+-- que un único detalle de documento se distribuya entre múltiples
+-- centros de costo con porcentajes específicos.
+-- =================================================================
+
+-- Paso 1: Crear la nueva tabla para la distribución de centros de costo.
+-- Esta tabla almacenará la relación N-a-N entre el detalle del documento y los centros de costo.
+CREATE TABLE IF NOT EXISTS `documento_detalle_distribucion` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `id_documento_detalle` INT NOT NULL,
+  `id_centro_costo` INT NOT NULL,
+  `porcentaje` DECIMAL(5, 2) NOT NULL,
+  CONSTRAINT `fk_distribucion_detalle` FOREIGN KEY (`id_documento_detalle`) REFERENCES `documentos_detalle`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_distribucion_centro_costo` FOREIGN KEY (`id_centro_costo`) REFERENCES `centros_costos`(`id`),
+  UNIQUE KEY `idx_distribucion_unica` (`id_documento_detalle`, `id_centro_costo`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Paso 2: Eliminar la columna `id_centro_costo` de `documentos_detalle`.
+-- Primero, verificamos si la columna existe antes de intentar eliminarla.
+-- También eliminamos la clave foránea asociada si existe.
+DELIMITER $$
+CREATE PROCEDURE `patch_remove_cc_from_detalle`()
+BEGIN
+    IF EXISTS (SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'documentos_detalle' AND COLUMN_NAME = 'id_centro_costo') THEN
+        -- Verificar si existe la clave foránea antes de eliminarla
+        IF EXISTS (SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'documentos_detalle' AND CONSTRAINT_NAME = 'fk_detalle_centro_costo') THEN
+            ALTER TABLE `documentos_detalle` DROP FOREIGN KEY `fk_detalle_centro_costo`;
+        END IF;
+        ALTER TABLE `documentos_detalle` DROP COLUMN `id_centro_costo`;
+    END IF;
+END$$
+DELIMITER ;
+CALL patch_remove_cc_from_detalle();
+DROP PROCEDURE patch_remove_cc_from_detalle;
+
+
+-- Paso 3: Modificar el SP para crear detalles de documento.
+-- Se elimina el parámetro `p_id_centro_costo` ya que ahora se manejará en una tabla separada.
+-- El ID del detalle insertado (`LAST_INSERT_ID()`) se usará en el backend para insertar en la tabla de distribución.
+DROP PROCEDURE IF EXISTS sp_create_documento_detalle;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_documento_detalle`(
+    IN p_id_documento INT,
+    IN p_item INT,
+    IN p_cantidad DECIMAL(15, 4),
+    IN p_descripcion VARCHAR(255),
+    IN p_id_concepto INT,
+    IN p_precio_unitario DECIMAL(15, 4),
+    IN p_precio_total DECIMAL(15, 2),
+    IN p_total_soles DECIMAL(15, 2),
+    IN p_total_dolares DECIMAL(15, 2),
+    OUT p_new_detalle_id INT
+)
+BEGIN
+    INSERT INTO documentos_detalle (
+        id_documento, item, cantidad, descripcion, id_concepto,
+        precio_unitario, precio_total, total_soles, total_dolares
+    ) VALUES (
+        p_id_documento, p_item, p_cantidad, p_descripcion, p_id_concepto,
+        p_precio_unitario, p_precio_total, p_total_soles, p_total_dolares
+    );
+    SET p_new_detalle_id = LAST_INSERT_ID();
+END$$
+DELIMITER ;
+
+-- Paso 4: Crear un nuevo SP para insertar en la tabla de distribución.
+-- Este SP se llamará en un bucle desde el backend para cada centro de costo asociado a un detalle.
+DROP PROCEDURE IF EXISTS sp_create_documento_detalle_distribucion;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_documento_detalle_distribucion`(
+    IN p_id_documento_detalle INT,
+    IN p_id_centro_costo INT,
+    IN p_porcentaje DECIMAL(5, 2)
+)
+BEGIN
+    INSERT INTO documento_detalle_distribucion (
+        id_documento_detalle, id_centro_costo, porcentaje
+    ) VALUES (
+        p_id_documento_detalle, p_id_centro_costo, p_porcentaje
+    );
+END$$
+DELIMITER ;
+
+-- Paso 5: Modificar el SP que lee los detalles del documento para incluir la distribución.
+-- Se utiliza GROUP_CONCAT y JSON_ARRAYAGG para agregar la información de distribución
+-- en un formato que el frontend pueda interpretar fácilmente.
+DROP PROCEDURE IF EXISTS sp_read_documento_detalle_by_id;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_documento_detalle_by_id`(IN p_id_documento INT)
+BEGIN
+    SELECT
+        dd.id,
+        dd.id_documento,
+        dd.item,
+        dd.cantidad,
+        dd.descripcion,
+        dd.id_concepto,
+        dd.precio_unitario,
+        dd.precio_total,
+        dd.total_soles,
+        dd.total_dolares,
+        (
+            SELECT JSON_ARRAYAGG(
+                JSON_OBJECT(
+                    'id_centro_costo', ddd.id_centro_costo,
+                    'porcentaje', ddd.porcentaje
+                )
+            )
+            FROM documento_detalle_distribucion ddd
+            WHERE ddd.id_documento_detalle = dd.id
+        ) AS distribucion
+    FROM
+        documentos_detalle dd
+    WHERE
+        dd.id_documento = p_id_documento
+    ORDER BY
+        dd.item ASC;
+END$$
+DELIMITER ;
+
+-- Paso 6: Modificar el SP `sp_delete_documento_detalle_by_id_documento`
+-- Aunque ON DELETE CASCADE debería manejarlo, es buena práctica ser explícito
+-- o asegurarse de que la FK está correctamente configurada.
+-- En este caso, confiaremos en ON DELETE CASCADE definido en el Paso 1.
+-- No se requiere ninguna acción aquí si la FK está bien definida.
+
+-- Paso 7: Modificar el SP `sp_read_all_documentos` para que el filtro de centro de costo
+-- ahora busque en la nueva tabla de distribución.
+DROP PROCEDURE IF EXISTS sp_read_all_documentos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_documentos`(
+    IN p_fecha_desde DATE,
+    IN p_fecha_hasta DATE,
+    IN p_id_tipo_documento INT,
+    IN p_serie_numero VARCHAR(31),
+    IN p_auxiliar VARCHAR(255),
+    IN p_id_centro_costo INT,
+    IN p_moneda VARCHAR(10),
+    IN p_page_size INT,
+    IN p_page_number INT
+)
+BEGIN
+    SET @where_clause = 'WHERE 1=1';
+    IF p_fecha_desde IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision >= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_fecha_hasta IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision <= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_id_tipo_documento IS NOT NULL AND p_id_tipo_documento != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.id_tipo_documento = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_serie_numero IS NOT NULL AND p_serie_numero != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND CONCAT(d.serie_documento, ''-'', d.numero_documento) LIKE ?'); SET p_serie_numero = CONCAT('%', p_serie_numero, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_auxiliar IS NOT NULL AND p_auxiliar != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND a.razon_social_nombres LIKE ?'); SET p_auxiliar = CONCAT('%', p_auxiliar, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+
+    -- Modificación clave: El filtro por centro de costo ahora debe unirse a la tabla de distribución.
+    IF p_id_centro_costo IS NOT NULL AND p_id_centro_costo != '' THEN
+        SET @where_clause = CONCAT(@where_clause, ' AND d.id IN (SELECT DISTINCT dd.id_documento FROM documentos_detalle dd JOIN documento_detalle_distribucion ddd ON dd.id = ddd.id_documento_detalle WHERE ddd.id_centro_costo = ?)');
+    ELSE
+        SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL');
+    END IF;
+
+    IF p_moneda IS NOT NULL AND p_moneda != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.moneda = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+
+    -- Query para obtener el conteo total de registros filtrados
+    SET @count_sql = CONCAT('SELECT COUNT(d.id) FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ', @where_clause);
+    PREPARE count_stmt FROM @count_sql;
+    EXECUTE count_stmt USING p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_id_centro_costo, p_moneda;
+    DEALLOCATE PREPARE count_stmt;
+
+    -- Query para obtener los datos paginados. Se mantiene el LEFT JOIN a centros_costos en el header por si se quiere mostrar el CC principal.
+    -- O se puede eliminar si ya no tiene sentido. Lo mantendré por ahora.
+    SET @data_sql = CONCAT(
+        'SELECT d.id, d.fecha_emision, td.nombre as tipo_documento, d.serie_documento, d.numero_documento, a.razon_social_nombres as auxiliar, cc.nombre as centro_costo, d.moneda, d.total, d.total_soles, d.total_dolares ',
+        'FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id LEFT JOIN centros_costos cc ON d.id_centro_costo = cc.id ',
+        @where_clause,
+        ' ORDER BY d.fecha_emision DESC, d.id DESC LIMIT ? OFFSET ?'
+    );
+    PREPARE data_stmt FROM @data_sql;
+    EXECUTE data_stmt USING p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_id_centro_costo, p_moneda, p_page_size, ((p_page_number - 1) * p_page_size);
+    DEALLOCATE PREPARE data_stmt;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -97,14 +97,59 @@ try {
             }
 
             // Insert new details for both create and update
-            $stmt_insert_detail = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            $stmt_insert_detail = $pdo->prepare("CALL sp_create_documento_detalle(?, ?, ?, ?, ?, ?, ?, ?, ?, @new_detalle_id)");
+            $stmt_insert_distribucion = $pdo->prepare("CALL sp_create_documento_detalle_distribucion(?, ?, ?)");
+
             foreach ($details as $index => $item) {
                 $item_total = (float)$item['cantidad'] * (float)$item['precio_unitario'];
                 $item_total_soles = $is_soles ? $item_total : $item_total * $tc;
                 $item_total_dolares = !$is_soles ? $item_total : $item_total / $tc;
                 $descripcion = $item['descripcion'] ?? '';
-                $id_centro_costo = $item['id_centro_costo'] ?? null;
-                $stmt_insert_detail->execute([$doc_id, $index + 1, $item['cantidad'], $descripcion, $item['id_concepto'], $id_centro_costo, $item['precio_unitario'], $item_total, $item_total_soles, $item_total_dolares]);
+
+                // 1. Insertar el detalle y obtener el nuevo ID
+                $stmt_insert_detail->execute([
+                    $doc_id,
+                    $index + 1,
+                    $item['cantidad'],
+                    $descripcion,
+                    $item['id_concepto'],
+                    $item['precio_unitario'],
+                    $item_total,
+                    $item_total_soles,
+                    $item_total_dolares
+                ]);
+                $stmt_insert_detail->closeCursor(); // Muy importante al usar OUT parameters
+                $new_detalle_id = $pdo->query("SELECT @new_detalle_id as new_id")->fetch(PDO::FETCH_ASSOC)['new_id'];
+
+                if (!$new_detalle_id) {
+                    throw new Exception("No se pudo crear el item del detalle: " . ($descripcion ?: ('Item ' . $index + 1)));
+                }
+
+                // 2. Insertar la distribución para este detalle
+                if (isset($item['distribucion']) && is_array($item['distribucion'])) {
+                    $total_porcentaje = 0;
+                    foreach($item['distribucion'] as $dist) {
+                        $total_porcentaje += (float)$dist['porcentaje'];
+                    }
+
+                    // Validar que la suma de porcentajes sea (aproximadamente) 100
+                    if (abs($total_porcentaje - 100) > 0.01 && count($item['distribucion']) > 0) {
+                        throw new Exception("La suma de porcentajes para el item '".($descripcion ?: ($index + 1))."' no es 100%. Suma actual: $total_porcentaje%");
+                    }
+
+                    foreach ($item['distribucion'] as $distribucion_item) {
+                        if (!empty($distribucion_item['id_centro_costo']) && !empty($distribucion_item['porcentaje'])) {
+                            $stmt_insert_distribucion->execute([
+                                $new_detalle_id,
+                                $distribucion_item['id_centro_costo'],
+                                $distribucion_item['porcentaje']
+                            ]);
+                        }
+                    }
+                } else {
+                     // Opcional: Lanzar un error si no se proporciona distribución para un item
+                     throw new Exception("No se proporcionó distribución de centro de costo para el item: " . ($descripcion ?: ('Item ' . $index + 1)));
+                }
             }
 
             // -- Procesamiento de Archivos Adjuntos --

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -190,7 +190,7 @@ $centros_costo = [];
                                 <th style="width: 10%;">Cant.</th>
                                 <th style="width: 25%;">Concepto</th>
                                 <th style="width: 20%;">Descripción</th>
-                                <th style="width: 15%;">CC</th>
+                                <th style="width: 15%;">Dist. CC</th>
                                 <th style="width: 10%;">P. Unit.</th>
                                 <th style="width: 10%;">Total</th>
                                 <th style="width: 5%;">Acción</th>
@@ -202,6 +202,41 @@ $centros_costo = [];
                     </table>
                     <button type="button" id="addRowBtn" class="btn btn-sm btn-success">Añadir Fila</button>
                 </fieldset>
+
+                <!-- Modal para Distribución de Centros de Costo -->
+                <div class="modal fade" id="distribucionCCModal" tabindex="-1" aria-labelledby="distribucionCCModalLabel" aria-hidden="true">
+                    <div class="modal-dialog modal-lg">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="distribucionCCModalLabel">Distribuir Centro de Costo</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <table class="table table-sm table-bordered">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th style="width: 60%;">Centro de Costo</th>
+                                            <th style="width: 30%;">Porcentaje (%)</th>
+                                            <th style="width: 10%;">Acción</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="distribucionBody">
+                                        <!-- Filas de distribución se insertarán aquí -->
+                                    </tbody>
+                                </table>
+                                <button type="button" id="addDistribucionRowBtn" class="btn btn-sm btn-success">Añadir Centro de Costo</button>
+                                <div class="mt-3">
+                                    <strong>Total Porcentaje: <span id="totalPorcentaje">0.00</span>%</strong>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                <button type="button" id="saveDistribucionBtn" class="btn btn-primary">Guardar Distribución</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
 
                 <!-- Totales -->
                 <div class="row justify-content-end">
@@ -250,13 +285,23 @@ $centros_costo = [];
         </td>
         <td><input type="text" class="form-control form-control-sm" name="descripcion"></td>
         <td>
-            <select class="form-select form-select-sm" name="id_centro_costo" required>
-                <option value="">Seleccione</option>
-            </select>
+            <button type="button" class="btn btn-sm btn-info distribucion-btn">Distribuir</button>
         </td>
         <td><input type="number" class="form-control form-control-sm" name="precio_unitario" step="0.0001" required></td>
         <td><input type="text" class="form-control form-control-sm total-row" name="precio_total" readonly></td>
         <td><button type="button" class="btn btn-sm btn-danger removeRowBtn">X</button></td>
+    </tr>
+</template>
+
+<template id="distribucionRowTemplate">
+    <tr>
+        <td>
+            <select class="form-select form-select-sm" name="id_centro_costo_dist" required>
+                <option value="">Seleccione un CC</option>
+            </select>
+        </td>
+        <td><input type="number" class="form-control form-control-sm" name="porcentaje_dist" step="0.01" min="0" max="100" required></td>
+        <td><button type="button" class="btn btn-sm btn-danger removeDistribucionRowBtn">X</button></td>
     </tr>
 </template>
 
@@ -293,6 +338,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const detalleBody = document.getElementById('detalleBody');
     const addRowBtn = document.getElementById('addRowBtn');
     const rowTemplate = document.getElementById('detalleRowTemplate');
+    const distribucionRowTemplate = document.getElementById('distribucionRowTemplate');
     const headerCentroCostoSelect = document.getElementById('id_centro_costo');
     const proyectoSelect = document.getElementById('id_proyecto');
     const subProyectoSelect = document.getElementById('id_sub_proyecto');
@@ -305,13 +351,21 @@ document.addEventListener('DOMContentLoaded', function() {
     const totalDolaresDisplay = document.getElementById('totalDolaresDisplay');
     const totalDolaresRow = document.getElementById('totalDolaresRow');
     const templateConceptoSelect = rowTemplate.content.querySelector('[name="id_concepto"]');
-    const templateCentroCostoSelect = rowTemplate.content.querySelector('[name="id_centro_costo"]');
+
+    // Modal elements
+    const distribucionModal = new bootstrap.Modal(document.getElementById('distribucionCCModal'));
+    const distribucionBody = document.getElementById('distribucionBody');
+    const addDistribucionRowBtn = document.getElementById('addDistribucionRowBtn');
+    const saveDistribucionBtn = document.getElementById('saveDistribucionBtn');
+    const totalPorcentajeSpan = document.getElementById('totalPorcentaje');
+    let activeDetailRow = null; // To track which detail row is being edited
 
     // --- CONSTANTS AND STATE ---
     const IGV_RATE = 0.18;
     const isEditMode = <?= $is_edit ? 'true' : 'false' ?>;
     const initialDetails = <?= json_encode($details) ?>;
     const initialHeader = <?= json_encode($header) ?>;
+    let centrosCostoOptions = []; // Cache for CC options
 
     // --- FUNCTIONS ---
 
@@ -319,20 +373,16 @@ document.addEventListener('DOMContentLoaded', function() {
         const newRow = rowTemplate.content.cloneNode(true);
         const tr = newRow.querySelector('tr');
 
-        const conceptSelect = tr.querySelector('[name="id_concepto"]');
-        const centroCostoSelect = tr.querySelector('[name="id_centro_costo"]');
+        // Store distribution data on the row itself
+        // When loading in edit mode, detail.distribucion is a JSON string from the DB, so it must be parsed.
+        const distribucionData = detail && detail.distribucion ? JSON.parse(detail.distribucion) : [];
+        tr.dataset.distribucion = JSON.stringify(distribucionData);
 
         if (detail) {
             tr.querySelector('[name="cantidad"]').value = detail.cantidad;
             tr.querySelector('[name="precio_unitario"]').value = detail.precio_unitario;
             tr.querySelector('[name="descripcion"]').value = detail.descripcion || '';
-            conceptSelect.value = detail.id_concepto;
-            centroCostoSelect.value = detail.id_centro_costo;
-        } else {
-            const headerCentroCostoId = headerCentroCostoSelect.value;
-            if (headerCentroCostoId) {
-                centroCostoSelect.value = headerCentroCostoId;
-            }
+            tr.querySelector('[name="id_concepto"]').value = detail.id_concepto;
         }
 
         detalleBody.appendChild(tr);
@@ -346,6 +396,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         tr.querySelectorAll('[name="cantidad"], [name="precio_unitario"]').forEach(input => {
             input.addEventListener('input', () => updateRowCalculations(tr));
+        });
+
+        tr.querySelector('.distribucion-btn').addEventListener('click', () => {
+            openDistribucionModal(tr);
         });
 
         updateRowCalculations(tr);
@@ -380,15 +434,85 @@ document.addEventListener('DOMContentLoaded', function() {
         igvDisplay.textContent = igv.toFixed(2);
         totalDisplay.textContent = total.toFixed(2);
         totalDolaresDisplay.textContent = (monedaSelect.value === 'SOLES' && tc > 0 ? total / tc : total).toFixed(2);
-
-
         updateTotalsVisibility();
     }
 
     function updateTotalsVisibility() {
-        totalDolaresRow.style.display = (monedaSelect.value === 'SOLES') ? 'none' : '';
+        totalDolaresRow.style.display = (monedaSelect.value === 'SOLES') ? 'none' : 'table-row';
     }
 
+    // --- Distribucion Modal Functions ---
+    function openDistribucionModal(detailRow) {
+        activeDetailRow = detailRow;
+        distribucionBody.innerHTML = '';
+        const distribucionData = JSON.parse(activeDetailRow.dataset.distribucion || '[]');
+        if (distribucionData.length > 0) {
+            distribucionData.forEach(dist => addDistribucionRow(dist));
+        } else {
+            addDistribucionRow(); // Add one empty row to start
+        }
+        updateTotalPorcentaje();
+        distribucionModal.show();
+    }
+
+    function addDistribucionRow(dist = null) {
+        const newRow = distribucionRowTemplate.content.cloneNode(true);
+        const ccSelect = newRow.querySelector('[name="id_centro_costo_dist"]');
+        updateSelectWithOptions(ccSelect, centrosCostoOptions, 'Seleccione un CC');
+
+        if (dist) {
+            ccSelect.value = dist.id_centro_costo;
+            newRow.querySelector('[name="porcentaje_dist"]').value = dist.porcentaje;
+        }
+
+        newRow.querySelector('.removeDistribucionRowBtn').addEventListener('click', (e) => {
+            e.target.closest('tr').remove();
+            updateTotalPorcentaje();
+        });
+
+        newRow.querySelector('[name="porcentaje_dist"]').addEventListener('input', updateTotalPorcentaje);
+        distribucionBody.appendChild(newRow);
+    }
+
+    function updateTotalPorcentaje() {
+        let total = 0;
+        distribucionBody.querySelectorAll('[name="porcentaje_dist"]').forEach(input => {
+            total += parseFloat(input.value) || 0;
+        });
+        totalPorcentajeSpan.textContent = total.toFixed(2);
+        totalPorcentajeSpan.style.color = Math.abs(total - 100) < 0.01 ? 'green' : 'red';
+    }
+
+    saveDistribucionBtn.addEventListener('click', () => {
+        const total = parseFloat(totalPorcentajeSpan.textContent);
+        if (Math.abs(total - 100) > 0.01) {
+            alert('El porcentaje total debe ser exactamente 100%.');
+            return;
+        }
+
+        const newDistribucionData = [];
+        let isValid = true;
+        distribucionBody.querySelectorAll('tr').forEach(row => {
+            const ccId = row.querySelector('[name="id_centro_costo_dist"]').value;
+            const porcentaje = row.querySelector('[name="porcentaje_dist"]').value;
+            if (!ccId || !porcentaje || parseFloat(porcentaje) <= 0) {
+                isValid = false;
+            }
+            newDistribucionData.push({ id_centro_costo: ccId, porcentaje: porcentaje });
+        });
+
+        if (!isValid) {
+            alert('Por favor, complete todos los campos de la distribución con valores válidos.');
+            return;
+        }
+
+        activeDetailRow.dataset.distribucion = JSON.stringify(newDistribucionData);
+        distribucionModal.hide();
+    });
+
+    addDistribucionRowBtn.addEventListener('click', () => addDistribucionRow());
+
+    // --- Data Fetching & Initialization ---
     function fetchSubProyectos(id_proyecto, selected_id = null) {
         subProyectoSelect.innerHTML = '<option value="">Cargando...</option>';
         if (!id_proyecto) {
@@ -424,18 +548,16 @@ document.addEventListener('DOMContentLoaded', function() {
         return str.replace(/[&<>"']/g, m => map[m]);
     }
 
-    function updateSelectWithOptions(selectElement, options, placeholder = 'Seleccione') {
-        const currentValue = selectElement.value;
+    function updateSelectWithOptions(selectElement, options, placeholder = 'Seleccione', selectedValue = null) {
+        const currentValue = selectedValue || selectElement.value;
         selectElement.innerHTML = `<option value="">${placeholder}</option>`;
-        let valueExists = false;
         if (Array.isArray(options)) {
             options.forEach(opt => {
                 const isSelected = opt.id == currentValue;
                 selectElement.options[selectElement.options.length] = new Option(opt.nombre, opt.id, isSelected, isSelected);
-                if(isSelected) valueExists = true;
             });
         }
-        if(valueExists) selectElement.value = currentValue;
+        if (currentValue) selectElement.value = currentValue;
     }
 
     function loadDropdownData(year) {
@@ -444,8 +566,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const fetchCentros = fetch(`../src/ajax/get_centros_costos_for_dropdown.php?año=${year}`)
             .then(response => response.ok ? response.json() : Promise.reject('Error de red'))
             .then(data => {
+                centrosCostoOptions = data; // Cache CC options
                 updateSelectWithOptions(headerCentroCostoSelect, data, 'Seleccione Centro de Costo');
-                updateSelectWithOptions(templateCentroCostoSelect, data, 'Seleccione Centro de Costo');
             });
 
         const fetchConceptos = fetch(`../src/ajax/get_conceptos_for_dropdown.php?año=${year}`)
@@ -467,6 +589,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const initialYear = new Date(fechaEmision + 'T00:00:00').getFullYear();
 
         loadDropdownData(initialYear).then(() => {
+            // Populate concept dropdowns in existing rows before adding new ones
+            const conceptSelects = document.querySelectorAll('[name="id_concepto"]');
+            conceptSelects.forEach(select => {
+                const currentValue = select.value;
+                updateSelectWithOptions(select, templateConceptoSelect.options, 'Seleccione Concepto', currentValue);
+            });
+
             if (isEditMode) {
                 if (initialHeader.id_centro_costo) {
                     headerCentroCostoSelect.value = initialHeader.id_centro_costo;
@@ -474,6 +603,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (initialHeader.id_proyecto) {
                     fetchSubProyectos(initialHeader.id_proyecto, initialHeader.id_sub_proyecto);
                 }
+                // Clear body before re-populating
+                detalleBody.innerHTML = '';
                 initialDetails.forEach(detail => addRow(detail));
             } else {
                 addRow();
@@ -521,20 +652,35 @@ document.addEventListener('DOMContentLoaded', function() {
         const submissionData = new FormData();
         const headerData = {};
         for (const element of form.elements) {
-            if (element.name && element.type !== 'file' && !element.closest('#detalleBody')) {
+            if (element.name && element.type !== 'file' && !element.closest('#detalleBody') && !element.closest('#distribucionCCModal')) {
                 headerData[element.name] = element.value;
             }
         }
         submissionData.append('header', JSON.stringify(headerData));
 
         const detailData = [];
+        let formIsValid = true;
         detalleBody.querySelectorAll('tr').forEach(row => {
             const rowData = {};
             row.querySelectorAll('input, select').forEach(input => {
                 if (input.name) rowData[input.name] = input.value;
             });
+
+            const distribucion = JSON.parse(row.dataset.distribucion || '[]');
+            if(distribucion.length === 0) {
+                formIsValid = false;
+            }
+            rowData.distribucion = distribucion;
             detailData.push(rowData);
         });
+
+        if (!formIsValid) {
+            alert('Cada item del detalle debe tener una distribución de Centros de Costo definida. Haga clic en "Distribuir" para cada fila.');
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Guardar Documento';
+            return;
+        }
+
         submissionData.append('details', JSON.stringify(detailData));
 
         const files = document.getElementById('adjuntos').files;
@@ -551,7 +697,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (data.success) {
                 window.location.href = `index.php?page=ingreso_documentos&success=${encodeURIComponent(data.message)}`;
             } else {
-                alert(data.message);
+                alert('Error: ' + data.message);
                 submitBtn.disabled = false;
                 submitBtn.textContent = 'Guardar Documento';
             }


### PR DESCRIPTION
This feature refactors the document detail section to allow a single line item's cost to be distributed across multiple cost centers with specific percentages.

Key changes:
- A new table `documento_detalle_distribucion` is created to store the percentage-based distribution.
- The `id_centro_costo` column is removed from `documentos_detalle`.
- Stored procedures for creating and reading documents are updated to support the new data structure.
- The backend `documentos_process.php` is updated to handle the nested distribution data, including server-side validation to ensure percentages sum to 100%.
- The frontend `ingreso_documentos_form.php` now features a modal for managing the cost center distribution for each line item, providing real-time validation and a dynamic user interface.