### PR TITLE
refactor: Remove header-level cost center controls

### DIFF
--- a/database/20250920_remove_header_cc.sql
+++ b/database/20250920_remove_header_cc.sql
@@ -1,0 +1,56 @@
+-- =================================================================
+-- PARCHE PARA ELIMINAR LÓGICA DE CENTRO DE COSTO DE LA GRILLA PRINCIPAL
+-- Fecha: 2025-09-20
+-- Autor: Jules AI
+-- Descripción: Este parche simplifica el SP `sp_read_all_documentos`
+-- eliminando el parámetro de filtro por centro de costo y la columna
+-- de centro de costo del resultado, ya que esta lógica ha sido
+-- eliminada de la interfaz de usuario.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_all_documentos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_documentos`(
+    IN p_anio INT,
+    IN p_fecha_desde DATE,
+    IN p_fecha_hasta DATE,
+    IN p_id_tipo_documento INT,
+    IN p_serie_numero VARCHAR(31),
+    IN p_auxiliar VARCHAR(255),
+    -- p_id_centro_costo REMOVED
+    IN p_moneda VARCHAR(10),
+    IN p_page_size INT,
+    IN p_page_number INT
+)
+BEGIN
+    -- Construcción de la cláusula WHERE dinámica
+    SET @where_clause = 'WHERE 1=1';
+    IF p_anio IS NOT NULL AND p_anio != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND YEAR(d.fecha_emision) = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_fecha_desde IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision >= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_fecha_hasta IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision <= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_id_tipo_documento IS NOT NULL AND p_id_tipo_documento != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.id_tipo_documento = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_serie_numero IS NOT NULL AND p_serie_numero != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND CONCAT(d.serie_documento, ''-'', d.numero_documento) LIKE ?'); SET p_serie_numero = CONCAT('%', p_serie_numero, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_auxiliar IS NOT NULL AND p_auxiliar != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND a.razon_social_nombres LIKE ?'); SET p_auxiliar = CONCAT('%', p_auxiliar, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_moneda IS NOT NULL AND p_moneda != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.moneda = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+
+    -- Query para obtener el conteo total de registros filtrados
+    SET @count_sql = CONCAT('SELECT COUNT(d.id) FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ', @where_clause);
+    PREPARE count_stmt FROM @count_sql;
+    EXECUTE count_stmt USING p_anio, p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_moneda;
+    DEALLOCATE PREPARE count_stmt;
+
+    -- Query para obtener los datos paginados
+    SET @data_sql = CONCAT(
+        'SELECT d.id, d.fecha_emision, td.nombre as tipo_documento, d.serie_documento, d.numero_documento, a.razon_social_nombres as auxiliar, d.moneda, d.total, d.total_soles, d.total_dolares, ',
+        -- Subconsulta para verificar si hay adjuntos
+        '(EXISTS(SELECT 1 FROM documento_adjuntos WHERE id_documento = d.id)) as tiene_adjuntos ',
+        'FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ',
+        @where_clause,
+        ' ORDER BY d.fecha_emision DESC, d.id DESC LIMIT ? OFFSET ?'
+    );
+    PREPARE data_stmt FROM @data_sql;
+    SET @offset = (p_page_number - 1) * p_page_size;
+    EXECUTE data_stmt USING p_anio, p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_moneda, p_page_size, @offset;
+    DEALLOCATE PREPARE data_stmt;
+END$$
+DELIMITER ;

--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -15,7 +15,6 @@ $f_fecha_hasta = $_GET['fecha_hasta'] ?? null;
 $f_id_tipo_documento = $_GET['id_tipo_documento'] ?? null;
 $f_serie_numero = $_GET['serie_numero'] ?? null;
 $f_auxiliar = $_GET['auxiliar'] ?? null;
-$f_id_centro_costo = $_GET['id_centro_costo'] ?? null;
 $f_moneda = $_GET['moneda'] ?? null;
 
 // Construir la cadena de consulta para la paginación
@@ -45,7 +44,6 @@ try {
         empty($f_id_tipo_documento) ? null : $f_id_tipo_documento,
         empty($f_serie_numero) ? null : $f_serie_numero,
         empty($f_auxiliar) ? null : $f_auxiliar,
-        empty($f_id_centro_costo) ? null : $f_id_centro_costo,
         empty($f_moneda) ? null : $f_moneda,
         $page_size,
         $current_page
@@ -130,15 +128,6 @@ try {
             <input type="text" id="auxiliar" name="auxiliar" value="<?= htmlspecialchars($f_auxiliar ?? '') ?>">
         </div>
         <div class="form-group">
-            <label for="centro_costo">Centro de Costo</label>
-            <select id="centro_costo" name="id_centro_costo">
-                <option value="">Todos</option>
-                 <?php foreach($centros_costo_list as $cc): ?>
-                    <option value="<?= $cc['id'] ?>" <?= (($f_id_centro_costo ?? null) == $cc['id']) ? 'selected' : '' ?>><?= htmlspecialchars($cc['nombre']) ?></option>
-                <?php endforeach; ?>
-            </select>
-        </div>
-        <div class="form-group">
             <label for="moneda">Moneda</label>
             <select id="moneda" name="moneda">
                 <option value="">Todas</option>
@@ -159,7 +148,6 @@ try {
                 <th>Tipo Documento</th>
                 <th>Serie y Número</th>
                 <th>Auxiliar</th>
-                <th>Centro de Costo</th>
                 <th>Moneda</th>
                 <th>Total</th>
                 <th style="width: 90px;">Acciones</th>
@@ -168,7 +156,7 @@ try {
         <tbody>
             <?php if (empty($documentos)): ?>
                 <tr>
-                    <td colspan="10" style="text-align: center;">No hay documentos que coincidan con los filtros.</td>
+                    <td colspan="9" style="text-align: center;">No hay documentos que coincidan con los filtros.</td>
                 </tr>
             <?php else: ?>
                 <?php foreach ($documentos as $doc): ?>
@@ -183,7 +171,6 @@ try {
                     <td><?= htmlspecialchars($doc['tipo_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['serie_documento'] . '-' . $doc['numero_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['auxiliar']) ?></td>
-                    <td><?= htmlspecialchars($doc['centro_costo']) ?></td>
                     <td><?= htmlspecialchars($doc['moneda']) ?></td>
                     <td style="text-align: right;"><?= htmlspecialchars(number_format($doc['total'], 2)) ?></td>
                     <td class="col-acciones">

--- a/src/pages/ingreso_documentos_form.php
+++ b/src/pages/ingreso_documentos_form.php
@@ -121,7 +121,7 @@ $centros_costo = [];
                                     </div>
                                 </div>
                                 <div class="row">
-                                     <div class="col-md-4 mb-3">
+                                     <div class="col-md-6 mb-3">
                                         <label for="id_proyecto" class="form-label">Proyecto</label>
                                         <select class="form-select" id="id_proyecto" name="id_proyecto" required>
                                             <option value="">Seleccione</option>
@@ -130,16 +130,10 @@ $centros_costo = [];
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
-                                    <div class="col-md-4 mb-3">
+                                    <div class="col-md-6 mb-3">
                                         <label for="id_sub_proyecto" class="form-label">Sub-Proyecto</label>
                                         <select class="form-select" id="id_sub_proyecto" name="id_sub_proyecto" required>
                                             <option value="">Seleccione un proyecto primero</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-md-4 mb-3">
-                                        <label for="id_centro_costo" class="form-label">Centro de Costo</label>
-                                         <select class="form-select" id="id_centro_costo" name="id_centro_costo" required>
-                                            <option value="">Seleccione</option>
                                         </select>
                                     </div>
                                 </div>
@@ -353,7 +347,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const addRowBtn = document.getElementById('addRowBtn');
     const rowTemplate = document.getElementById('detalleRowTemplate');
     const distribucionRowTemplate = document.getElementById('distribucionRowTemplate');
-    const headerCentroCostoSelect = document.getElementById('id_centro_costo');
     const proyectoSelect = document.getElementById('id_proyecto');
     const subProyectoSelect = document.getElementById('id_sub_proyecto');
     const fechaInput = document.getElementById('fecha_emision');
@@ -662,7 +655,6 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(response => response.ok ? response.json() : Promise.reject('Error de red'))
             .then(data => {
                 centrosCostoOptions = data; // Cache CC options
-                updateSelectWithOptions(headerCentroCostoSelect, data, 'Seleccione Centro de Costo');
             });
 
         const fetchConceptos = fetch(`../src/ajax/get_conceptos_for_dropdown.php?año=${year}`)
@@ -692,9 +684,6 @@ document.addEventListener('DOMContentLoaded', function() {
             });
 
             if (isEditMode) {
-                if (initialHeader.id_centro_costo) {
-                    headerCentroCostoSelect.value = initialHeader.id_centro_costo;
-                }
                 if (initialHeader.id_proyecto) {
                     fetchSubProyectos(initialHeader.id_proyecto, initialHeader.id_sub_proyecto);
                 }


### PR DESCRIPTION
This commit removes the now-redundant header-level 'Centro de Costo' controls from the application, as per user request. Cost centers are now managed exclusively at the detail line level.

Changes include:
- In `ingreso_documentos_form.php`: The 'Centro de Costo' dropdown has been removed from the document header section, and its associated JavaScript logic has been deleted.
- In `ingreso_documentos.php`: The 'Centro de Costo' column has been removed from the main document grid, and the corresponding search filter has also been removed.
- A new SQL patch updates the `sp_read_all_documentos` stored procedure, removing the parameter and logic related to the obsolete header cost center.