### PR TITLE
fix(docs): Correct invalid parameter count on document list page

### DIFF
--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -36,7 +36,7 @@ try {
     $years_list = $pdo->query("CALL sp_get_years_with_documents()")->fetchAll(PDO::FETCH_ASSOC);
 
     // Llamar al SP con los filtros y la paginación
-    $stmt = $pdo->prepare("CALL sp_read_all_documentos(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    $stmt = $pdo->prepare("CALL sp_read_all_documentos(?, ?, ?, ?, ?, ?, ?, ?, ?)");
     $params = [
         empty($f_anio) ? null : $f_anio,
         empty($f_fecha_desde) ? null : $f_fecha_desde,


### PR DESCRIPTION
This commit fixes a fatal error (SQLSTATE[HY093]: Invalid parameter number) on the main document listing page.

The error was caused by a mismatch between the number of '?' tokens in the PREPARE statement and the number of variables being passed to the `sp_read_all_documentos` stored procedure after a previous refactoring.

The `prepare` call in `ingreso_documentos.php` has been corrected to have 9 placeholders instead of 10, aligning it with the updated stored procedure and the parameters array.