### PR TITLE
fix: Restore cost center column in document list view

### DIFF
--- a/database/20250920_restore_cc_column.sql
+++ b/database/20250920_restore_cc_column.sql
@@ -1,11 +1,11 @@
 -- =================================================================
--- PARCHE PARA ELIMINAR LÓGICA DE CENTRO DE COSTO DE LA GRILLA PRINCIPAL
+-- PARCHE PARA RESTAURAR LA COLUMNA DE CENTRO DE COSTO EN LA GRILLA
 -- Fecha: 2025-09-20
 -- Autor: Jules AI
--- Descripción: Este parche simplifica el SP `sp_read_all_documentos`
--- eliminando el parámetro de filtro por centro de costo y la columna
--- de centro de costo del resultado, ya que esta lógica ha sido
--- eliminada de la interfaz de usuario.
+-- Descripción: Este parche actualiza el SP `sp_read_all_documentos`
+-- para volver a mostrar la información de los centros de costo en la
+-- grilla principal, usando una lista separada por comas. El filtro
+-- por centro de costo permanece eliminado.
 -- =================================================================
 
 DROP PROCEDURE IF EXISTS sp_read_all_documentos;
@@ -17,7 +17,6 @@ CREATE PROCEDURE `sp_read_all_documentos`(
     IN p_id_tipo_documento INT,
     IN p_serie_numero VARCHAR(31),
     IN p_auxiliar VARCHAR(255),
-    -- p_id_centro_costo REMOVED
     IN p_moneda VARCHAR(10),
     IN p_page_size INT,
     IN p_page_number INT
@@ -42,6 +41,8 @@ BEGIN
     -- Query para obtener los datos paginados
     SET @data_sql = CONCAT(
         'SELECT d.id, d.fecha_emision, td.nombre as tipo_documento, d.serie_documento, d.numero_documento, a.razon_social_nombres as auxiliar, d.moneda, d.total, d.total_soles, d.total_dolares, ',
+        -- Subconsulta para obtener la lista de centros de costo
+        '(SELECT GROUP_CONCAT(DISTINCT cc.nombre SEPARATOR '', '') FROM documentos_detalle dd JOIN documento_detalle_distribucion ddd ON dd.id = ddd.id_documento_detalle JOIN centros_costos cc ON ddd.id_centro_costo = cc.id WHERE dd.id_documento = d.id) as centro_costo, ',
         -- Subconsulta para verificar si hay adjuntos
         '(EXISTS(SELECT 1 FROM documento_adjuntos WHERE id_documento = d.id)) as tiene_adjuntos ',
         'FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ',

--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -148,6 +148,7 @@ try {
                 <th>Tipo Documento</th>
                 <th>Serie y Número</th>
                 <th>Auxiliar</th>
+                <th>Centro de Costo</th>
                 <th>Moneda</th>
                 <th>Total</th>
                 <th style="width: 90px;">Acciones</th>
@@ -156,7 +157,7 @@ try {
         <tbody>
             <?php if (empty($documentos)): ?>
                 <tr>
-                    <td colspan="9" style="text-align: center;">No hay documentos que coincidan con los filtros.</td>
+                    <td colspan="10" style="text-align: center;">No hay documentos que coincidan con los filtros.</td>
                 </tr>
             <?php else: ?>
                 <?php foreach ($documentos as $doc): ?>
@@ -171,6 +172,7 @@ try {
                     <td><?= htmlspecialchars($doc['tipo_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['serie_documento'] . '-' . $doc['numero_documento']) ?></td>
                     <td><?= htmlspecialchars($doc['auxiliar']) ?></td>
+                    <td><?= htmlspecialchars($doc['centro_costo']) ?></td>
                     <td><?= htmlspecialchars($doc['moneda']) ?></td>
                     <td style="text-align: right;"><?= htmlspecialchars(number_format($doc['total'], 2)) ?></td>
                     <td class="col-acciones">


### PR DESCRIPTION
This commit restores the 'Centro de Costo' column to the main document listing page, as per user feedback clarifying a previous request.

The column will now display a comma-separated list of all cost centers associated with a document's details, providing a clear overview. The search filter for a single cost center remains hidden, as it is no longer relevant with the new distribution model.

Changes include:
- Re-adding the 'Centro de Costo' column to the table in `ingreso_documentos.php`.
- Updating the `sp_read_all_documentos` stored procedure to fetch and concatenate the list of cost center names for each document.
- Deleting the previous, incorrect SQL patch that removed this functionality.