### PR TITLE
fix: Resolve integrity constraint violation on document save

### DIFF
--- a/database/20250920_make_header_cc_nullable.sql
+++ b/database/20250920_make_header_cc_nullable.sql
@@ -1,0 +1,62 @@
+-- =================================================================
+-- PARCHE PARA HACER EL CC DEL HEADER NULABLE Y OPCIONAL
+-- Fecha: 2025-09-20
+-- Autor: Jules AI
+-- Descripción: Este parche soluciona un error de guardado que ocurría
+-- al eliminar el CC del header del formulario. Se modifica la tabla
+-- `documentos` para permitir que `id_centro_costo` sea NULL y se
+-- actualizan los SPs de creación y edición para eliminar el parámetro.
+-- =================================================================
+
+-- Paso 1: Modificar la tabla `documentos` para permitir NULL en `id_centro_costo`
+-- Esto es necesario porque el campo ya no se envía desde el formulario.
+ALTER TABLE `documentos` MODIFY COLUMN `id_centro_costo` INT NULL;
+
+
+-- Paso 2: Redefinir SP para crear encabezado de documento sin el parámetro de CC
+DROP PROCEDURE IF EXISTS sp_create_documento_header;
+DELIMITER $$
+CREATE PROCEDURE `sp_create_documento_header`(
+    IN p_id_tipo_documento INT, IN p_id_proyecto INT, IN p_id_sub_proyecto INT,
+    IN p_id_auxiliar INT, IN p_id_usuario_registro INT, IN p_serie_documento VARCHAR(10),
+    IN p_numero_documento VARCHAR(20), IN p_fecha_emision DATE, IN p_moneda ENUM('SOLES', 'DOLARES'),
+    IN p_tipo_cambio DECIMAL(10, 4), IN p_subtotal DECIMAL(15, 2), IN p_igv DECIMAL(15, 2),
+    IN p_total DECIMAL(15, 2), IN p_total_soles DECIMAL(15, 2), IN p_total_dolares DECIMAL(15, 2),
+    IN p_glosa TEXT, IN p_observaciones TEXT, OUT p_new_id INT
+)
+BEGIN
+    INSERT INTO documentos (
+        id_tipo_documento, id_proyecto, id_sub_proyecto, id_auxiliar, id_usuario_registro,
+        serie_documento, numero_documento, fecha_emision, moneda, tipo_cambio,
+        subtotal, igv, total, total_soles, total_dolares, glosa, observaciones
+    ) VALUES (
+        p_id_tipo_documento, p_id_proyecto, p_id_sub_proyecto, p_id_auxiliar, p_id_usuario_registro,
+        p_serie_documento, p_numero_documento, p_fecha_emision, p_moneda, p_tipo_cambio,
+        p_subtotal, p_igv, p_total, p_total_soles, p_total_dolares, p_glosa, p_observaciones
+    );
+    SET p_new_id = LAST_INSERT_ID();
+END$$
+DELIMITER ;
+
+
+-- Paso 3: Redefinir SP para actualizar encabezado de documento sin el parámetro de CC
+DROP PROCEDURE IF EXISTS sp_update_documento_header;
+DELIMITER $$
+CREATE PROCEDURE `sp_update_documento_header`(
+    IN p_id INT, IN p_id_tipo_documento INT, IN p_id_proyecto INT, IN p_id_sub_proyecto INT,
+    IN p_id_auxiliar INT, IN p_serie_documento VARCHAR(10), IN p_numero_documento VARCHAR(20),
+    IN p_fecha_emision DATE, IN p_moneda ENUM('SOLES', 'DOLARES'), IN p_tipo_cambio DECIMAL(10, 4),
+    IN p_subtotal DECIMAL(15, 2), IN p_igv DECIMAL(15, 2), IN p_total DECIMAL(15, 2),
+    IN p_total_soles DECIMAL(15, 2), IN p_total_dolares DECIMAL(15, 2), IN p_glosa TEXT, IN p_observaciones TEXT
+)
+BEGIN
+    UPDATE documentos SET
+        id_tipo_documento = p_id_tipo_documento, id_proyecto = p_id_proyecto,
+        id_sub_proyecto = p_id_sub_proyecto, id_auxiliar = p_id_auxiliar,
+        serie_documento = p_serie_documento, numero_documento = p_numero_documento,
+        fecha_emision = p_fecha_emision, moneda = p_moneda, tipo_cambio = p_tipo_cambio,
+        subtotal = p_subtotal, igv = p_igv, total = p_total, total_soles = p_total_soles,
+        total_dolares = p_total_dolares, glosa = p_glosa, observaciones = p_observaciones
+    WHERE id = p_id;
+END$$
+DELIMITER ;

--- a/src/actions/documentos_process.php
+++ b/src/actions/documentos_process.php
@@ -82,14 +82,14 @@ try {
 
             if ($action === 'update') {
                 $doc_id = $header['id_documento'];
-                $stmt_update = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-                $stmt_update->execute([$doc_id, $header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
+                $stmt_update = $pdo->prepare("CALL sp_update_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                $stmt_update->execute([$doc_id, $header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_auxiliar'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
                 $stmt_delete_details = $pdo->prepare("CALL sp_delete_documento_detalle_by_id_documento(?)");
                 $stmt_delete_details->execute([$doc_id]);
                 $response['message'] = 'Documento actualizado con éxito.';
             } else { // create
-                $stmt_create = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
-                $stmt_create->execute([$header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_centro_costo'], $header['id_auxiliar'], $_SESSION['user_id'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
+                $stmt_create = $pdo->prepare("CALL sp_create_documento_header(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, @new_id)");
+                $stmt_create->execute([$header['id_tipo_documento'], $header['id_proyecto'], $header['id_sub_proyecto'], $header['id_auxiliar'], $_SESSION['user_id'], $header['serie_documento'], $header['numero_documento'], $header['fecha_emision'], $header['moneda'], $tc, $subtotal, $igv, $total, $total_soles, $total_dolares, $header['glosa'], $header['observaciones'] ?? null]);
                 $stmt_create->closeCursor();
                 $doc_id = $pdo->query("SELECT @new_id as new_id")->fetch(PDO::FETCH_ASSOC)['new_id'];
                 if (!$doc_id) throw new Exception("No se pudo crear el encabezado del documento.");


### PR DESCRIPTION
This commit fixes a critical bug that caused an 'Integrity constraint violation' (SQLSTATE[23000]) when saving a document after the header-level cost center field was removed from the UI.

The error occurred because the `documentos.id_centro_costo` column was still mandatory in the database, but the application no longer provided a value for it.

Changes:
- A new SQL patch (`database/20250920_make_header_cc_nullable.sql`) has been added to alter the `documentos.id_centro_costo` column to be nullable, making it optional.
- The `sp_create_documento_header` and `sp_update_documento_header` stored procedures have been updated to remove the now-obsolete cost center parameter.
- The backend script `src/actions/documentos_process.php` has been updated to call the modified stored procedures with the correct number of parameters.