### PR TITLE
feat: Re-agregar filtro de centro de costo en la grilla principal

### DIFF
--- a/database/20250920_reagregar_filtro_cc.sql
+++ b/database/20250920_reagregar_filtro_cc.sql
@@ -1,0 +1,67 @@
+-- =================================================================
+-- PARCHE PARA RE-AGREGAR FILTRO DE CENTRO DE COSTO A LA GRILLA
+-- Fecha: 2025-09-20
+-- Autor: Jules AI
+-- Descripción: Este parche restaura la funcionalidad de filtrado por
+-- centro de costo en la grilla principal. Se actualiza el SP
+-- `sp_read_all_documentos` para que acepte el parámetro de filtro y
+-- busque en la tabla de distribución de detalles.
+-- =================================================================
+
+DROP PROCEDURE IF EXISTS sp_read_all_documentos;
+DELIMITER $$
+CREATE PROCEDURE `sp_read_all_documentos`(
+    IN p_anio INT,
+    IN p_fecha_desde DATE,
+    IN p_fecha_hasta DATE,
+    IN p_id_tipo_documento INT,
+    IN p_serie_numero VARCHAR(31),
+    IN p_auxiliar VARCHAR(255),
+    IN p_id_centro_costo INT,
+    IN p_moneda VARCHAR(10),
+    IN p_page_size INT,
+    IN p_page_number INT
+)
+BEGIN
+    -- Construcción de la cláusula WHERE dinámica
+    SET @where_clause = 'WHERE 1=1';
+    SET @join_for_filter = '';
+
+    IF p_anio IS NOT NULL AND p_anio != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND YEAR(d.fecha_emision) = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_fecha_desde IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision >= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_fecha_hasta IS NOT NULL THEN SET @where_clause = CONCAT(@where_clause, ' AND d.fecha_emision <= ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_id_tipo_documento IS NOT NULL AND p_id_tipo_documento != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.id_tipo_documento = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_serie_numero IS NOT NULL AND p_serie_numero != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND CONCAT(d.serie_documento, ''-'', d.numero_documento) LIKE ?'); SET p_serie_numero = CONCAT('%', p_serie_numero, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+    IF p_auxiliar IS NOT NULL AND p_auxiliar != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND a.razon_social_nombres LIKE ?'); SET p_auxiliar = CONCAT('%', p_auxiliar, '%'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+
+    IF p_id_centro_costo IS NOT NULL AND p_id_centro_costo != '' THEN
+        SET @join_for_filter = ' JOIN documentos_detalle dd_filter ON d.id = dd_filter.id_documento JOIN documento_detalle_distribucion ddd_filter ON dd_filter.id = ddd_filter.id_documento_detalle ';
+        SET @where_clause = CONCAT(@where_clause, ' AND ddd_filter.id_centro_costo = ? ');
+    ELSE
+        SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL');
+    END IF;
+
+    IF p_moneda IS NOT NULL AND p_moneda != '' THEN SET @where_clause = CONCAT(@where_clause, ' AND d.moneda = ?'); ELSE SET @where_clause = CONCAT(@where_clause, ' AND ? IS NULL'); END IF;
+
+    -- Query para obtener el conteo total de registros filtrados (corregido para incluir el JOIN del filtro)
+    SET @count_sql = CONCAT('SELECT COUNT(DISTINCT d.id) FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ', @join_for_filter, @where_clause);
+    PREPARE count_stmt FROM @count_sql;
+    EXECUTE count_stmt USING p_anio, p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_id_centro_costo, p_moneda;
+    DEALLOCATE PREPARE count_stmt;
+
+    -- Query para obtener los datos paginados
+    SET @data_sql = CONCAT(
+        'SELECT DISTINCT d.id, d.fecha_emision, td.nombre as tipo_documento, d.serie_documento, d.numero_documento, a.razon_social_nombres as auxiliar, d.moneda, d.total, d.total_soles, d.total_dolares, ',
+        '(SELECT GROUP_CONCAT(DISTINCT cc.nombre SEPARATOR '', '') FROM documentos_detalle dd JOIN documento_detalle_distribucion ddd ON dd.id = ddd.id_documento_detalle JOIN centros_costos cc ON ddd.id_centro_costo = cc.id WHERE dd.id_documento = d.id) as centro_costo, ',
+        '(EXISTS(SELECT 1 FROM documento_adjuntos WHERE id_documento = d.id)) as tiene_adjuntos ',
+        'FROM documentos d JOIN tipos_documento td ON d.id_tipo_documento = td.id JOIN auxiliares a ON d.id_auxiliar = a.id ',
+        @join_for_filter,
+        @where_clause,
+        ' ORDER BY d.fecha_emision DESC, d.id DESC LIMIT ? OFFSET ?'
+    );
+    PREPARE data_stmt FROM @data_sql;
+    SET @offset = (p_page_number - 1) * p_page_size;
+    EXECUTE data_stmt USING p_anio, p_fecha_desde, p_fecha_hasta, p_id_tipo_documento, p_serie_numero, p_auxiliar, p_id_centro_costo, p_moneda, p_page_size, @offset;
+    DEALLOCATE PREPARE data_stmt;
+END$$
+DELIMITER ;

--- a/src/pages/ingreso_documentos.php
+++ b/src/pages/ingreso_documentos.php
@@ -15,6 +15,7 @@ $f_fecha_hasta = $_GET['fecha_hasta'] ?? null;
 $f_id_tipo_documento = $_GET['id_tipo_documento'] ?? null;
 $f_serie_numero = $_GET['serie_numero'] ?? null;
 $f_auxiliar = $_GET['auxiliar'] ?? null;
+$f_id_centro_costo = $_GET['id_centro_costo'] ?? null;
 $f_moneda = $_GET['moneda'] ?? null;
 
 // Construir la cadena de consulta para la paginación
@@ -36,7 +37,7 @@ try {
     $years_list = $pdo->query("CALL sp_get_years_with_documents()")->fetchAll(PDO::FETCH_ASSOC);
 
     // Llamar al SP con los filtros y la paginación
-    $stmt = $pdo->prepare("CALL sp_read_all_documentos(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    $stmt = $pdo->prepare("CALL sp_read_all_documentos(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     $params = [
         empty($f_anio) ? null : $f_anio,
         empty($f_fecha_desde) ? null : $f_fecha_desde,
@@ -44,6 +45,7 @@ try {
         empty($f_id_tipo_documento) ? null : $f_id_tipo_documento,
         empty($f_serie_numero) ? null : $f_serie_numero,
         empty($f_auxiliar) ? null : $f_auxiliar,
+        empty($f_id_centro_costo) ? null : $f_id_centro_costo,
         empty($f_moneda) ? null : $f_moneda,
         $page_size,
         $current_page
@@ -126,6 +128,15 @@ try {
         <div class="form-group">
             <label for="auxiliar">Auxiliar</label>
             <input type="text" id="auxiliar" name="auxiliar" value="<?= htmlspecialchars($f_auxiliar ?? '') ?>">
+        </div>
+        <div class="form-group">
+            <label for="centro_costo">Centro de Costo</label>
+            <select id="centro_costo" name="id_centro_costo">
+                <option value="">Todos</option>
+                 <?php foreach($centros_costo_list as $cc): ?>
+                    <option value="<?= $cc['id'] ?>" <?= (($f_id_centro_costo ?? null) == $cc['id']) ? 'selected' : '' ?>><?= htmlspecialchars($cc['nombre']) ?></option>
+                <?php endforeach; ?>
+            </select>
         </div>
         <div class="form-group">
             <label for="moneda">Moneda</label>


### PR DESCRIPTION
Este commit restaura la funcionalidad de filtrado por 'Centro de Costo' en la página de listado de documentos, según la solicitud del usuario.

Cambios realizados:
- En `ingreso_documentos.php`, se ha vuelto a añadir el campo de selección para el filtro de centro de costo.
- Se ha actualizado la llamada al procedimiento almacenado para incluir el parámetro del filtro.
- Se ha creado un nuevo script SQL (`database/20250920_reagregar_filtro_cc.sql`) que redefine el procedimiento `sp_read_all_documentos`.
- El procedimiento almacenado ahora filtra los documentos que contienen el centro de costo seleccionado en cualquiera de las distribuciones de sus detalles.