### PR TITLE
feat(dashboard): Reducir el tamaño de los gráficos del dashboard

### DIFF
--- a/src/pages/inicio.php
+++ b/src/pages/inicio.php
@@ -39,18 +39,22 @@
 </section>
 
 <!-- Gráfico de Barras -->
-<section class="card mb-4">
-    <div class="card-header">
-        Total de Documentos en Soles por Mes y Centro de Costo
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <section class="card mb-4">
+            <div class="card-header">
+                Total de Documentos en Soles por Mes y Centro de Costo
+            </div>
+            <div class="card-body">
+                <canvas id="barChart"></canvas>
+            </div>
+        </section>
     </div>
-    <div class="card-body">
-        <canvas id="barChart"></canvas>
-    </div>
-</section>
+</div>
 
 <!-- Gráficos Circulares -->
-<section class="row">
-    <div class="col-lg-6 mb-4">
+<section class="row justify-content-center">
+    <div class="col-lg-4 mb-4">
         <div class="card h-100">
             <div class="card-header">
                 Importes en Soles por Centro de Costo (Mes Actual)
@@ -60,7 +64,7 @@
             </div>
         </div>
     </div>
-    <div class="col-lg-6 mb-4">
+    <div class="col-lg-4 mb-4">
         <div class="card h-100">
             <div class="card-header">
                 Importes por Tipo de Documento (Mes y C.Costo Actual)


### PR DESCRIPTION
Este commit ajusta el layout de la página del dashboard (`inicio.php`) para reducir el tamaño de los gráficos, según la solicitud del usuario.

Cambios:
- El gráfico de barras ahora está contenido dentro de una columna más estrecha (`col-lg-8`) y centrado en la página para reducir su tamaño horizontal.
- Los dos gráficos circulares han sido ajustados de columnas de `col-lg-6` a `col-lg-4`, reduciendo su tamaño a la mitad y manteniéndolos centrados en su fila.

Estos cambios hacen que la visualización del dashboard sea más compacta.