### PR TITLE
feat(dashboard): Aplicar reducción de tamaño adicional a los gráficos

### DIFF
--- a/src/pages/inicio.php
+++ b/src/pages/inicio.php
@@ -40,7 +40,7 @@
 
 <!-- Gráfico de Barras -->
 <div class="row justify-content-center">
-    <div class="col-lg-8">
+    <div class="col-lg-4">
         <section class="card mb-4">
             <div class="card-header">
                 Total de Documentos en Soles por Mes y Centro de Costo
@@ -54,7 +54,7 @@
 
 <!-- Gráficos Circulares -->
 <section class="row justify-content-center">
-    <div class="col-lg-4 mb-4">
+    <div class="col-lg-2 mb-4">
         <div class="card h-100">
             <div class="card-header">
                 Importes en Soles por Centro de Costo (Mes Actual)
@@ -64,7 +64,7 @@
             </div>
         </div>
     </div>
-    <div class="col-lg-4 mb-4">
+    <div class="col-lg-2 mb-4">
         <div class="card h-100">
             <div class="card-header">
                 Importes por Tipo de Documento (Mes y C.Costo Actual)


### PR DESCRIPTION
Este commit aplica una segunda reducción de tamaño (50% del tamaño actual) a los gráficos del dashboard, según la solicitud específica del usuario.

Cambios en `inicio.php`:
- La columna del gráfico de barras se ha reducido de `col-lg-8` a `col-lg-4`.
- Las columnas de los gráficos circulares se han reducido de `col-lg-4` a `col-lg-2`.

Esto resulta en gráficos significativamente más compactos en el dashboard.