### PR TITLE
feat(ui): Añadir logo al menú lateral

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -17,6 +17,9 @@
     <div class="container-fluid">
         <div class="main-wrapper">
             <aside class="sidebar">
+            <div class="sidebar-header text-center py-3">
+                <img src="https://placehold.co/150x150/FFFFFF/4F81BD/png?text=Logo" alt="Logo del Sistema" style="width: 80px; height: 80px; border-radius: 50%; border: 2px solid #fff;">
+            </div>
             <div class="logo">
                 <button id="sidebarToggleBtn" class="btn btn-link text-white"><i class="fas fa-bars"></i></button>
                 <span class="logo-text">ERP-Plus Docs.</span>


### PR DESCRIPTION
Este commit añade un logo de marcador de posición en la parte superior del menú lateral (sidebar), justo encima del nombre del sistema, como fue solicitado.

Cambios:
- Se ha modificado `src/includes/header.php`.
- Se ha agregado un nuevo `div` (`sidebar-header`) para contener la imagen del logo.
- Se ha insertado una etiqueta `<img>` que apunta a una URL de un marcador de posición.
- Se han aplicado estilos CSS en línea para dar al logo un tamaño de 80x80px, hacerlo circular y añadirle un borde para una mejor apariencia visual.

El usuario podrá reemplazar fácilmente la URL del marcador de posición por la de su logo definitivo.