### PR TITLE
fix(ui): Corregir la ruta del logo en el menú lateral

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -18,7 +18,7 @@
         <div class="main-wrapper">
             <aside class="sidebar">
             <div class="sidebar-header text-center py-3">
-                <img src="https://placehold.co/150x150/FFFFFF/4F81BD/png?text=Logo" alt="Logo del Sistema" style="width: 80px; height: 80px; border-radius: 50%; border: 2px solid #fff;">
+                <img src="images/LOGO-solo.png" alt="Logo del Sistema" style="width: 80px; height: 80px; border-radius: 50%; border: 2px solid #fff;">
             </div>
             <div class="logo">
                 <button id="sidebarToggleBtn" class="btn btn-link text-white"><i class="fas fa-bars"></i></button>


### PR DESCRIPTION
Este commit actualiza la ruta de la imagen del logo en `src/includes/header.php`.

El cambio reemplaza la URL del marcador de posición por una ruta relativa (`images/LOGO-solo.png`) que funcionará correctamente cuando el usuario coloque su archivo de logo en la carpeta `public/images/`, como se le ha instruido.

Esto soluciona el problema reportado por el usuario de que la imagen no cargaba y prepara el sistema para que el logo se muestre automáticamente una vez que el archivo sea subido al lugar correcto.