### PR TITLE
feat: Show aggregated data on chart for all cost centers

### DIFF
--- a/public/js/inicio_charts.js
+++ b/public/js/inicio_charts.js
@@ -58,12 +58,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         actualizarBarChart(anio);
         actualizarPieChart1(anio, mes);
-        if (idCentroCosto) {
-            actualizarPieChart2(anio, mes, idCentroCosto);
-        } else {
-            // Si no hay centro de costo seleccionado, limpiar el gráfico 2 o mostrar un mensaje
-            if (pieChart2) pieChart2.destroy();
-        }
+        actualizarPieChart2(anio, mes, idCentroCosto);
     }
 
     function actualizarBarChart(anio) {
@@ -146,6 +141,14 @@ document.addEventListener('DOMContentLoaded', function () {
             .then(data => {
                 if (pieChart2) pieChart2.destroy();
 
+                // Actualizar título de la tarjeta
+                const cardHeader = ctxPie2.canvas.closest('.card').querySelector('.card-header');
+                const selectedCentroCostoText = filtroCentroCosto.options[filtroCentroCosto.selectedIndex].text;
+                if (idCentroCosto) {
+                    cardHeader.textContent = `Importes por Tipo de Documento (Mes y C.Costo: ${selectedCentroCostoText})`;
+                } else {
+                    cardHeader.textContent = 'Importes por Tipo de Documento (Mes Actual - Todos los C.Costos)';
+                }
                 const labels = data.map(item => item.nombre_tipo_documento);
                 const importes = data.map(item => parseFloat(item.total_soles));
 

--- a/src/ajax/get_reporte_pie_chart2.php
+++ b/src/ajax/get_reporte_pie_chart2.php
@@ -8,21 +8,35 @@ header('Content-Type: application/json');
 
 $anio = isset($_GET['anio']) ? (int)$_GET['anio'] : date('Y');
 $mes = isset($_GET['mes']) ? (int)$_GET['mes'] : date('m');
-$id_centro_costo = isset($_GET['id_centro_costo']) ? (int)$_GET['id_centro_costo'] : null;
-
-if ($id_centro_costo === null) {
-    echo json_encode([]);
-    exit;
-}
+$id_centro_costo = isset($_GET['id_centro_costo']) ? (int)$_GET['id_centro_costo'] : 0;
 
 try {
     $pdo = getDbConnection();
-    $stmt = $pdo->prepare("CALL sp_reporte_total_soles_por_tipo_documento_y_centro_costo(?, ?, ?)");
-    $stmt->execute([$anio, $mes, $id_centro_costo]);
-    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+    if ($id_centro_costo) {
+        // Si se especifica un centro de costo, usa el SP existente
+        $stmt = $pdo->prepare("CALL sp_reporte_total_soles_por_tipo_documento_y_centro_costo(?, ?, ?)");
+        $stmt->execute([$anio, $mes, $id_centro_costo]);
+    } else {
+        // Si no se especifica (o es 'Todos'), agrega por tipo de documento en todos los centros de costo
+        $query = "
+            SELECT
+                td.nombre as nombre_tipo_documento,
+                SUM(d.total_soles) as total_soles
+            FROM documentos d
+            JOIN tipos_documento td ON d.id_tipo_documento = td.id
+            WHERE YEAR(d.fecha_emision) = ? AND MONTH(d.fecha_emision) = ?
+            GROUP BY td.nombre
+            ORDER BY total_soles DESC
+        ";
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([$anio, $mes]);
+    }
+
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode($data);
 
 } catch (Exception $e) {
+    // En caso de error, devuelve un array vacío para no romper el frontend
     echo json_encode([]);
 }


### PR DESCRIPTION
Modified the 'Importes por Tipo de Documento' chart on the dashboard.

When the 'Todos' (All) option is selected in the Cost Center filter, the chart now displays the total amounts for each document type, aggregated across all cost centers for the selected month and year.

- Updated `src/ajax/get_reporte_pie_chart2.php` to execute a new query that aggregates data when no specific cost center is selected.
- Updated `public/js/inicio_charts.js` to always render the chart and to dynamically update the chart's title to reflect the current filter selection (either a specific cost center or 'Todos').